### PR TITLE
Add EMPTY_SET Opcode

### DIFF
--- a/fickling/pickle.py
+++ b/fickling/pickle.py
@@ -837,6 +837,13 @@ class BinInt2(BinInt1):
     name = "BININT2"
 
 
+class EmptySet(Opcode):
+    name = "EMPTY_SET"
+
+    def run(self, interpreter: Interpreter):
+        interpreter.stack.append(ast.Set())
+
+
 class EmptyList(Opcode):
     name = "EMPTY_LIST"
 


### PR DESCRIPTION
Thanks for this great tool! This Opcode appears to be necessary to fickle some uses of PyTorch modules such as `torch.nn.Linear`, which I'd love to have support for.

Here is an example which triggers the following error:

```py
# example.py
import pickle
from fickling.pickle import Pickled
from torch import nn

filename = "model.pt"
model = nn.Linear(2, 1)

with open(filename, "wb") as model_file:
    pickle.dump(model, model_file)

with open(filename, "rb") as model_file:
    pickled = Pickled.load(model_file)
```

```
$ python example.py
Traceback (most recent call last):
  File "~/ml-attacks/src/pickle_deserialization/example.py", line 12, in <module>
    pickled = Pickled.load(model_file)
  File "~/ml-attacks/.venv/lib/python3.9/site-packages/fickling/pickle.py", line 343, in load
    opcodes.append(Opcode(info=info, argument=arg, data=data, position=pos))
  File "~/ml-attacks/.venv/lib/python3.9/site-packages/fickling/pickle.py", line 105, in __new__
    raise NotImplementedError(f"TODO: Add support for Opcode {info.name}")
NotImplementedError: TODO: Add support for Opcode EMPTY_SET
```

Is anything else needed?