### PR TITLE
Add DICT and INT opcodes

### DIFF
--- a/fickling/pickle.py
+++ b/fickling/pickle.py
@@ -892,3 +892,34 @@ class BinBytes(ConstantOpcode):
 
 class ShortBinBytes(BinBytes):
     name = "SHORT_BINBYTES"
+
+
+class Int(ConstantOpcode):
+    name = "INT"
+
+
+class Dict(Opcode):
+    name = "DICT"
+
+    def run(self, interpreter: Interpreter):
+        
+        i = 0
+        keys = []
+        values = []
+
+        while interpreter.stack:
+            obj = interpreter.stack.pop()
+            if isinstance(obj, MarkObject):
+                break
+            if i == 0:
+                values.append(obj)
+            elif i == 1:
+                keys.append(obj)
+            i = (i + 1) % 2
+        else:
+            raise ValueError("Exhausted the stack while searching for a MarkObject!")
+
+        if len(keys) != len(values):
+            raise ValueError(f"Number of keys ({len(keys)}) and values ({len(values)}) for DICT do not match")            
+
+        interpreter.stack.append(ast.Dict(keys=keys, values=values))


### PR DESCRIPTION
Two very simple additions:
The `INT` opcode is used to declare constant integer values.
The `DICT` opcode reads values from the stack until it reaches a `MARK` opcode, alternating between keys and values.

Take the following script:
```python
import ast
import pickletools
from fickling.pickle import Pickled

if __name__ == '__main__':
	
	pickled = b"(I1\nI2\nd."

	for op, arg, pos in pickletools.genops(pickled):
		print(f"{pos}: {op.name} {arg}")

	ast_data = Pickled.load(pickled).ast
	print(ast.dump(ast_data))
```

Before, it would output:
```
0: MARK None
1: INT 1
4: INT 2
7: DICT None
8: STOP None
Traceback (most recent call last):
  File "test.py", line 12, in <module>
    ast_data = Pickled.load(pickled).ast
  File "/home/carlos/.local/lib/python3.7/site-packages/fickling/pickle.py", line 343, in load
    opcodes.append(Opcode(info=info, argument=arg, data=data, position=pos))
  File "/home/carlos/.local/lib/python3.7/site-packages/fickling/pickle.py", line 105, in __new__
    raise NotImplementedError(f"TODO: Add support for Opcode {info.name}")
NotImplementedError: TODO: Add support for Opcode INT
```

Now it outputs:
```
0: MARK None
1: INT 1
4: INT 2
7: DICT None
8: STOP None
Module(body=[Assign(targets=[Name(id='result', ctx=Store())], value=Dict(keys=[Constant(value=1)], values=[Constant(value=2)]))])
```
