### PR TITLE
Adds support for the LONG_BINGET opcode

### DIFF
--- a/fickling/pickle.py
+++ b/fickling/pickle.py
@@ -851,7 +851,7 @@ class EmptySet(Opcode):
     name = "EMPTY_SET"
 
     def run(self, interpreter: Interpreter):
-        interpreter.stack.append(ast.Set())
+        interpreter.stack.append(ast.Set([]))
 
 
 class EmptyList(Opcode):

--- a/fickling/pickle.py
+++ b/fickling/pickle.py
@@ -763,6 +763,13 @@ class BinGet(Opcode):
         interpreter.stack.append(interpreter.memory[self.arg])
 
 
+class LongBinGet(Opcode):
+    name = "LONG_BINGET"
+
+    def run(self, interpreter: Interpreter):
+        interpreter.stack.append(interpreter.memory[self.arg])
+
+
 class Get(Opcode):
     name = "GET"
 
@@ -879,9 +886,6 @@ class Appends(StackSliceOpcode):
             raise ValueError(f"Expected a list on the stack, but instead found {list_obj!r}")
 
 
-# TODO (Carson) figure out floats
-# https://github.com/python/cpython/blob/main/Lib/pickle.py#L782
-# Floats are apart of ast.Constant (pretty sure)
 class BinFloat(ConstantOpcode):
     name = "BINFLOAT"
 
@@ -902,7 +906,6 @@ class Dict(Opcode):
     name = "DICT"
 
     def run(self, interpreter: Interpreter):
-        
         i = 0
         keys = []
         values = []


### PR DESCRIPTION
Also fixes a bug where empty sets would cause an error for some versions of Python that require `ast.Set` to always take an argument.