### PR TITLE
meta: bump minimum python to 3.7, scan deps with pip-audit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,6 +28,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools
         pip install .[dev]
+    - name: Scan with pip-audit
+      uses: trailofbits/gh-action-pip-audit@v0.0.4
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author="Trail of Bits",
     version="0.0.3",
     packages=find_packages(exclude=["test"]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=requirements,
     extras_require={
         "dev": ["flake8", "pytest", "twine"],


### PR DESCRIPTION
3.6 is EOL and not supported by `pip-audit` so I went ahead and removed it, but I can re-add it and manually exclude it from the test if you'd like instead.

Signed-off-by: William Woodruff <william@trailofbits.com>