### PR TITLE
Make sure to inject our code after PROTO and FRAME

### DIFF
--- a/fickling/pickle.py
+++ b/fickling/pickle.py
@@ -735,6 +735,23 @@ class Interpreter:
 class Proto(NoOp):
     name = "PROTO"
 
+    @staticmethod
+    def create(version: int) -> "Proto":
+        return Proto(version)
+
+    def encode_body(self) -> bytes:
+        return bytes([self.version])
+
+    @property
+    def version(self) -> int:
+        if self.arg is None:
+            return 0
+        elif isinstance(self.arg, int):
+            return self.arg
+        else:
+            # Endianness shouldn't really matter here because there is only one byte for the version
+            return int.from_bytes(self.arg, "big", signed=False)
+
 
 class Global(Opcode):
     name = "GLOBAL"

--- a/fickling/pickle.py
+++ b/fickling/pickle.py
@@ -416,15 +416,21 @@ class Pickled(OpcodeSequence):
         # and then either immediately call the `eval` with a `Reduce` opcode (the default)
         # or optionally insert the `Reduce` at the end (and hope that the existing code cleans up its stack so it
         # remains how we left it! TODO: Add code to emulate the code afterward and confirm that the stack is sane!
-        self.insert(0, Global.create(module, attr))
-        self.insert(1, Mark())
-        i = 1
-        for arg in args:
+        i = 0
+        while isinstance(self[i], (Proto, Frame)):
             i += 1
+        self.insert(i, Global.create(module, attr))
+        i += 1
+        self.insert(i, Mark())
+        i += 1
+        for arg in args:
             self.insert(i, ConstantOpcode.new(arg))
-        self.insert(i + 1, Tuple())
+            i += 1
+        self.insert(i, Tuple())
+        i += 1
         if run_first:
-            self.insert(i + 2, Reduce())
+            self.insert(i, Reduce())
+            i += 1
             if use_output_as_unpickle_result:
                 self.insert(-1, Pop())
         else:

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -112,3 +112,11 @@ class TestInterpreter(TestCase):
         self.assertEqual(len(unused), 1)
         self.assertIn("_var0", unused)
         self.assertFalse(check_safety(loaded))
+
+    def test_duplicate_proto(self):
+        pickled = dumps([1, 2, 3, 4])
+        loaded = Pickled.load(pickled)
+        self.assertTrue(check_safety(loaded))
+        loaded.insert(-1, fpickle.Proto.create(1))
+        loaded.insert(-1, fpickle.Proto.create(2))
+        self.assertFalse(check_safety(loaded))


### PR DESCRIPTION
Resolves issue #30.

When injecting new code, preserve leading `PROTO` and `FRAME` opcodes.

Also adds an analysis to detect invalid `PROTO` opcodes that can be an indicator of tampering.