### PR TITLE
added 2 unsafe imports (nt and posix)

### DIFF
--- a/fickling/pickle.py
+++ b/fickling/pickle.py
@@ -613,6 +613,8 @@ class Pickled(OpcodeSequence):
                 "__builtins__",
                 "builtins",
                 "os",
+                "posix",
+                "nt",
                 "subprocess",
                 "sys",
                 "builtins",


### PR DESCRIPTION
os module is converted to posix/nt on unix/windows accordingly.

For example, running in python3 on linux the following:
```
class cls1(object):
    def __reduce__(self):
        import os
        return (os.system, ("echo 1234",))

import pickle
pickle.dumps(cls1())

```
will return:
b'\x80\x04\x95$\x00\x00\x00\x00\x00\x00\x00\x8c\x05**posix**\x94\x8c\x06system\x94\x93\x94\x8c\techo 1234\x94\x85\x94R\x94.'