### PR TITLE
Add unsafe functions

### DIFF
--- a/fickling/analysis.py
+++ b/fickling/analysis.py
@@ -198,6 +198,8 @@ class OvertlyBadEvals(Analysis):
                 or shortened.startswith("exec(")
                 or shortened.startswith("compile(")
                 or shortened.startswith("open(")
+                or shortened.startswith("_run_code(")
+                or shortened.startswith("execWrapper(")
             ):
                 # this is overtly bad, so record it and print it at the end
                 yield AnalysisResult(

--- a/fickling/pickle.py
+++ b/fickling/pickle.py
@@ -613,6 +613,8 @@ class Pickled(OpcodeSequence):
                 "__builtins__",
                 "builtins",
                 "os",
+                "posix",
+                "nt",
                 "subprocess",
                 "sys",
                 "builtins",


### PR DESCRIPTION
Adding detection of two potentially malicious functions of eligble libraries, solving this issue https://github.com/trailofbits/fickling/issues/36

Exploits:
```
class cls1(object):
    def __reduce__(self):
        import torch
        return (torch.os.system, ("echo 1234",))

class cls2(object):
    def __reduce__(self):
        import runpy
        return (runpy._run_code, ('print(123)', {}))

with open('cls1.data', 'wb') as f:
  pickle.dump(cls1(), f)

with open('cls2.data', 'wb') as f:
  pickle.dump(cls2(), f)

```