### PR TITLE
Support Python 3.8+

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     uses: trailofbits/.github/.github/workflows/make-lint.yml@v0.1.3
     with:
       language: "python"
-      python-version: "3.7"
+      python-version: "3.8"
 
   lint-markdown:
     uses: trailofbits/.github/.github/workflows/make-lint.yml@v0.1.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and [DEF CON 2021 talk](https://www.youtube.com/watch?v=bZ0m_H_dEJI).
 
 ## Installation
 
-Fickling has been tested on Python 3.6 through Python 3.9 and has very few dependencies.
+Fickling has been tested on Python 3.8 through Python 3.11 and has very few dependencies.
 It can be installed through pip:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,44 +8,23 @@ dynamic = ["version"]
 description = "A static analyzer and interpreter for Python pickle data"
 readme = "README.md"
 license = { file = "LICENSE" }
-authors = [
-  { name = "Trail of Bits", email = "opensource@trailofbits.com" }
-]
+authors = [{ name = "Trail of Bits", email = "opensource@trailofbits.com" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Console",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
   "Programming Language :: Python :: 3 :: Only",
-  "Topic :: Utilities"
+  "Topic :: Utilities",
 ]
-dependencies = [
-  "astunparse ~= 1.6.3"
-]
-requires-python = ">=3.7"
+dependencies = ["astunparse ~= 1.6.3"]
+requires-python = ">=3.8"
 
 [project.optional-dependencies]
-lint = [
-  "black",
-  "mypy",
-  "ruff",
-]
-test = [
-  "pytest",
-  "pytest-cov",
-  "coverage[toml]",
-]
-dev = [
-  "build",
-  "fickling[lint,test]",
-  "twine",
-]
-examples = [
-  "numpy",
-  "pytorchfi~=0.4.1",
-  "torch~=1.9.0",
-  "torchvision~=0.10.0",
-]
+lint = ["black", "mypy", "ruff"]
+test = ["pytest", "pytest-cov", "coverage[toml]"]
+dev = ["build", "fickling[lint,test]", "twine"]
+examples = ["numpy", "pytorchfi~=0.4.1", "torch~=1.9.0", "torchvision~=0.10.0"]
 
 [project.scripts]
 "fickling" = "fickling.__main__:main"


### PR DESCRIPTION
This drops references to EOL'd Python versions.