### PR TITLE
Fix wrong order of dict entries.

### DIFF
--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -1430,7 +1430,7 @@ class Dict(Opcode):
                 f"Number of keys ({len(keys)}) and values ({len(values)}) for DICT do not match"
             )
 
-        interpreter.stack.append(ast.Dict(keys=keys, values=values))
+        interpreter.stack.append(ast.Dict(keys=reversed(keys), values=reversed(values)))
 
 
 if sys.version_info < (3, 9):


### PR DESCRIPTION
For a bit of more context, see [here](https://intrigus.org/research/2023/10/29/cyber-security-rumble-finals-ctf-2023-elkcip-writeup/#bugfixing-fickling--wrong-order-of-dict-entries).