### PR TITLE
Make Torch an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ following PyTorch file formats:
 
 * **PyTorch v0.1.1**: Tar file with sys_info, pickle, storages, and tensors
 * **PyTorch v0.1.10**: Stacked pickle files
-* **TorchScript v1.0**: ZIP file with model.json and constants.pkl (a JSON file and a pickle file)
-* **TorchScript v1.1**: ZIP file with model.json and attribute.pkl (a JSON file and a pickle file)
-* **TorchScript v1.3**: ZIP file with data.pkl and constants.pkl (2 pickle files)
-* **TorchScript v1.4**: ZIP file with data.pkl, constants.pkl, and version (2 pickle files and a folder)
+* **TorchScript v1.0**: ZIP file with model.json
+* **TorchScript v1.1**: ZIP file with model.json and attributes.pkl
+* **TorchScript v1.3**: ZIP file with data.pkl and constants.pkl
+* **TorchScript v1.4**: ZIP file with data.pkl, constants.pkl, and version set at 2 or higher (2 pickle files and a folder)
 * **PyTorch v1.3**: ZIP file containing data.pkl (1 pickle file)
 * **PyTorch model archive format[ZIP]**: ZIP file that includes Python code files and pickle files
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Both the library and command line utility can be installed through pip:
 python -m pip install fickling
 ```
 
+PyTorch is an optional dependency of Fickling. Therefore, in order to use Fickling's `pytorch`
+and `polyglot` modules, you should run:
+
+```bash
+python -m pip install fickling[torch]
+```
+
 ## Malicious file detection
 
 Fickling can seamlessly be integrated into your codebase to detect and halt the loading of malicious

--- a/fickling/polyglot.py
+++ b/fickling/polyglot.py
@@ -14,10 +14,10 @@ PyTorch file format identification:
 We currently support the following PyTorch file formats:
 • PyTorch v0.1.1: Tar file with sys_info, pickle, storages, and tensors
 • PyTorch v0.1.10: Stacked pickle files
-• TorchScript v1.0: ZIP file with model.json and constants.pkl (a JSON file and a pickle file)
-• TorchScript v1.1: ZIP file with model.json and attribute.pkl (a JSON file and a pickle file)
+• TorchScript v1.0: ZIP file with model.json 
+• TorchScript v1.1: ZIP file with model.json and attributes.pkl (a JSON file and a pickle file)
 • TorchScript v1.3: ZIP file with data.pkl and constants.pkl (2 pickle files)
-• TorchScript v1.4: ZIP file with data.pkl, constants.pkl, and version (2 pickle files and a folder)
+• TorchScript v1.4: ZIP file with data.pkl, constants.pkl, and version set at 2 or higher (2 pickle files and a folder)
 • PyTorch v1.3: ZIP file containing data.pkl (1 pickle file)
 • PyTorch model archive format[ZIP]: ZIP file that includes Python code files and pickle files
 
@@ -99,7 +99,7 @@ def find_file_properties(file_path, print_properties=False):
             "has_data_pkl": False,
             "has_version": False,
             "has_model_json": False,
-            "has_attribute_pkl": False,
+            "has_attributes_pkl": False,
         }
         if is_torch_zip:
             torch_zip_checks = [
@@ -107,7 +107,7 @@ def find_file_properties(file_path, print_properties=False):
                 "constants.pkl",
                 "version",
                 "model.json",
-                "attribute.pkl",
+                "attributes.pkl",
             ]
             torch_zip_results = {
                 f"has_{'_'.join(f.split('.'))}": check_and_find_in_zip(
@@ -163,7 +163,7 @@ def check_for_corruption(properties):
     if properties["is_torch_zip"]:
         if (
             properties["has_model_json"]
-            and not properties["has_attribute_pkl"]
+            and not properties["has_attributes_pkl"]
             and not properties["has_constants_pkl"]
         ):
             corrupted = True
@@ -188,7 +188,7 @@ def identify_pytorch_file_format(file, print_properties=False, print_results=Fal
             (["has_data_pkl", "has_constants_pkl", "has_version"], "TorchScript v1.4"),
             (["has_data_pkl", "has_constants_pkl"], "TorchScript v1.3"),
             (["has_model_json", "has_constants_pkl"], "TorchScript v1.0"),
-            (["has_model_json", "has_attribute_pkl"], "TorchScript v1.1"),
+            (["has_model_json", "has_attributes_pkl"], "TorchScript v1.1"),
             (["has_data_pkl"], "PyTorch v1.3"),
         ]
         formats = [

--- a/fickling/polyglot.py
+++ b/fickling/polyglot.py
@@ -3,6 +3,7 @@ import shutil
 import sys
 import tarfile
 import zipfile
+
 from fickling.fickle import Pickled, StackedPickle
 
 """
@@ -11,10 +12,10 @@ PyTorch file format identification:
 We currently support the following PyTorch file formats:
 • PyTorch v0.1.1: Tar file with sys_info, pickle, storages, and tensors
 • PyTorch v0.1.10: Stacked pickle files
-• TorchScript v1.0: ZIP file with model.json 
+• TorchScript v1.0: ZIP file with model.json
 • TorchScript v1.1: ZIP file with model.json and attributes.pkl (a JSON file and a pickle file)
 • TorchScript v1.3: ZIP file with data.pkl and constants.pkl (2 pickle files)
-• TorchScript v1.4: ZIP file with data.pkl, constants.pkl, and version set at 2 or higher (2 pickle files and a folder)
+• TorchScript v1.4: ZIP file with data.pkl, constants.pkl, and version set at 2 or higher
 • PyTorch v1.3: ZIP file containing data.pkl (1 pickle file)
 • PyTorch model archive format[ZIP]: ZIP file that includes Python code files and pickle files
 
@@ -27,9 +28,12 @@ Another useful reference is https://github.com/lutzroeder/netron/blob/main/sourc
 try:
     from torch.serialization import _is_zipfile
 except ModuleNotFoundError:
-    raise ImportError("The 'torch' module is required for this functionality."
-                      "PyTorch is now an optional dependency in Fickling."
-                      "Please use pip install '.[torch]'")
+    raise ImportError(
+        "The 'torch' module is required for this functionality."
+        "PyTorch is now an optional dependency in Fickling."
+        "Please use pip install '.[torch]'"
+    )
+
 
 def check_and_find_in_zip(
     zip_path, file_name_or_extension, return_path=False, check_extension=False

--- a/fickling/polyglot.py
+++ b/fickling/polyglot.py
@@ -3,9 +3,6 @@ import shutil
 import sys
 import tarfile
 import zipfile
-
-from torch.serialization import _is_zipfile
-
 from fickling.fickle import Pickled, StackedPickle
 
 """
@@ -28,7 +25,7 @@ Another useful reference is https://github.com/lutzroeder/netron/blob/main/sourc
 """
 
 try:
-    import torch
+    from torch.serialization import _is_zipfile
 except ModuleNotFoundError:
     raise ImportError("The 'torch' module is required for this functionality."
                       "PyTorch is now an optional dependency in Fickling."

--- a/fickling/polyglot.py
+++ b/fickling/polyglot.py
@@ -27,6 +27,12 @@ If any new PyTorch file formats are made, that should be added to this code.
 Another useful reference is https://github.com/lutzroeder/netron/blob/main/source/pytorch.js.
 """
 
+try:
+    import torch
+except ModuleNotFoundError:
+    raise ImportError("The 'torch' module is required for this functionality."
+                      "PyTorch is now an optional dependency in Fickling."
+                      "Please use pip install '.[torch]'")
 
 def check_and_find_in_zip(
     zip_path, file_name_or_extension, return_path=False, check_extension=False

--- a/fickling/polyglot.py
+++ b/fickling/polyglot.py
@@ -31,7 +31,7 @@ except ModuleNotFoundError:
     raise ImportError(
         "The 'torch' module is required for this functionality."
         "PyTorch is now an optional dependency in Fickling."
-        "Please use pip install '.[torch]'"
+        "Please use `pip install fickling[torch]`"
     )
 
 

--- a/fickling/pytorch.py
+++ b/fickling/pytorch.py
@@ -10,9 +10,12 @@ from fickling.fickle import Pickled
 try:
     import torch
 except ModuleNotFoundError:
-    raise ImportError("The 'torch' module is required for this functionality."
-                      "PyTorch is now an optional dependency in Fickling."
-                      "Please use pip install '.[torch]'")
+    raise ImportError(
+        "The 'torch' module is required for this functionality."
+        "PyTorch is now an optional dependency in Fickling."
+        "Please use pip install '.[torch]'"
+    )
+
 
 class BaseInjection(torch.nn.Module):
     # This class allows you to combine the payload and original model

--- a/fickling/pytorch.py
+++ b/fickling/pytorch.py
@@ -9,6 +9,12 @@ import torch
 import fickling.polyglot
 from fickling.fickle import Pickled
 
+try:
+    import torch
+except ModuleNotFoundError:
+    raise ImportError("The 'torch' module is required for this functionality."
+                      "PyTorch is now an optional dependency in Fickling."
+                      "Please use pip install '.[torch]'")
 
 class BaseInjection(torch.nn.Module):
     # This class allows you to combine the payload and original model

--- a/fickling/pytorch.py
+++ b/fickling/pytorch.py
@@ -13,7 +13,7 @@ except ModuleNotFoundError:
     raise ImportError(
         "The 'torch' module is required for this functionality."
         "PyTorch is now an optional dependency in Fickling."
-        "Please use pip install '.[torch]'"
+        "Please use `pip install fickling[torch]`"
     )
 
 

--- a/fickling/pytorch.py
+++ b/fickling/pytorch.py
@@ -4,8 +4,6 @@ import zipfile
 from pathlib import Path
 from typing import Optional, Set
 
-import torch
-
 import fickling.polyglot
 from fickling.fickle import Pickled
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.8"
 [project.optional-dependencies]
 torch = ["torch >= 2.1.0", "torchvision >= 0.16.1"]
 lint = ["black", "mypy", "ruff"]
-test = ["pytest", "pytest-cov", "coverage[toml]"]
+test = ["pytest", "pytest-cov", "coverage[toml]", "torch >= 2.1.0", "torchvision >= 0.16.1"]
 dev = ["build", "fickling[lint,test]", "twine", "torch >= 2.1.0", "torchvision >= 0.16.1"]
 examples = ["numpy", "pytorchfi"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,14 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Topic :: Utilities",
 ]
-dependencies = ["astunparse ~= 1.6.3", "torch >= 2.1.0", "torchvision >= 0.16.1"]
+dependencies = ["astunparse ~= 1.6.3"]
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
+torch = ["torch >= 2.1.0", "torchvision >= 0.16.1"]
 lint = ["black", "mypy", "ruff"]
 test = ["pytest", "pytest-cov", "coverage[toml]"]
-dev = ["build", "fickling[lint,test]", "twine"]
+dev = ["build", "fickling[lint,test]", "twine", "torch >= 2.1.0", "torchvision >= 0.16.1"]
 examples = ["numpy", "pytorchfi"]
 
 [project.scripts]

--- a/test/test_polyglot.py
+++ b/test/test_polyglot.py
@@ -128,7 +128,7 @@ class TestPolyglotModule(unittest.TestCase):
             "has_constants_pkl": False,
             "has_version": True,
             "has_model_json": False,
-            "has_attribute_pkl": False,
+            "has_attributes_pkl": False,
         }
         self.assertEqual(properties, proper_result)
 
@@ -144,7 +144,7 @@ class TestPolyglotModule(unittest.TestCase):
             "has_constants_pkl": False,
             "has_version": True,
             "has_model_json": False,
-            "has_attribute_pkl": False,
+            "has_attributes_pkl": False,
         }
         self.assertEqual(properties, proper_result)
 
@@ -160,7 +160,7 @@ class TestPolyglotModule(unittest.TestCase):
             "has_constants_pkl": True,
             "has_version": True,
             "has_model_json": False,
-            "has_attribute_pkl": False,
+            "has_attributes_pkl": False,
         }
         self.assertEqual(properties, proper_result)
 
@@ -176,7 +176,7 @@ class TestPolyglotModule(unittest.TestCase):
             "has_data_pkl": False,
             "has_version": False,
             "has_model_json": False,
-            "has_attribute_pkl": False,
+            "has_attributes_pkl": False,
         }
         self.assertEqual(properties, proper_result)
 


### PR DESCRIPTION
This PR makes PyTorch an optional dependency. It also updates the PyTorch file formats list both to clarify it and fix a typo. 