### PR TITLE
Add pty to unsafeimports

### DIFF
--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -768,6 +768,7 @@ on the Pickled object instead"""
                 "builtins",
                 "os",
                 "posix",
+                "pty",
                 "nt",
                 "subprocess",
                 "sys",

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -49,11 +49,11 @@ class TestHook(unittest.TestCase):
         with open("unsafe_pty.pickle", "wb") as f:
             f.write(payload_pty)
 
-        try:
-            numpy.load("unsafe.pickle", allow_pickle=True)
-            numpy.load("unsafe_pty.pickle", allow_pickle=True)
-        except UnpicklingError as e:
-            if isinstance(e.__cause__, UnsafeFileError):
-                pass
-            else:
-                self.fail(e)
+        for f in ["unsafe.pickle", "unsafe_pty.pickle"]:
+            try:
+                numpy.load(f, allow_pickle=True)
+            except UnpicklingError as e:
+                if isinstance(e.__cause__, UnsafeFileError):
+                    pass
+                else:
+                    self.fail(e)

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -39,13 +39,19 @@ class TestHook(unittest.TestCase):
                 return (os.system, ("echo 'I should have been stopped by the hook'",))
 
         payload = Payload()
+        # Validate that pty-based execution is captured
+        payload_pty = b'''(cpty\nspawn\nS"id"\no.'''
+
 
         # Save the payload in a pickle file
         with open("unsafe.pickle", "wb") as f:
             pickle.dump(payload, f)
+        with open("unsafe_pty.pickle", "wb") as f:
+            f.write(payload_pty)
 
         try:
             numpy.load("unsafe.pickle", allow_pickle=True)
+            numpy.load("unsafe_pty.pickle", allow_pickle=True)
         except UnpicklingError as e:
             if isinstance(e.__cause__, UnsafeFileError):
                 pass


### PR DESCRIPTION
The following code produces a pickle file that fickling fails to detect as malicious:

```
import pickle
import pickletools

payload = b'''(cpty\nspawn\nS"id"\no.'''
pickletools.dis(payload, annotate=1)

with open('pwn.pkl', 'wb') as f:
    f.write(payload)
```

This is because this technique uses `pty` and does not leave _var0 unused. This PR adds `pty` to `unsafe_imports` as a quick fix to ensure the primitive behind this technique is detected.