### PR TITLE
benchmarking - update check_content for byte support

### DIFF
--- a/pickle_scanning_benchmark/download.py
+++ b/pickle_scanning_benchmark/download.py
@@ -97,8 +97,12 @@ def hf_download_pickle_files(
 
 def _check_content(content):
     # Typical access error from HF API
-    if content.startswith("Access to model"):
-        raise Exception("Can not access model file")
+    if isinstance(content, bytes):
+        if content.startswith(b"Access to model"):
+            raise Exception("Can not access model file")
+    else:
+        if content.startswith("Access to model"):
+            raise Exception("Can not access model file")
 
 
 def _download_pickle_file(url, file, outdir):


### PR DESCRIPTION
When attempting to download a file, resp.content for me was a byte object. Updated the code to ensure it parsed both bytes or string response.