### PR TITLE
Update requirements.txt to support fickling.analysis.BadCalls

### DIFF
--- a/pickle_scanning_benchmark/requirements.txt
+++ b/pickle_scanning_benchmark/requirements.txt
@@ -1,4 +1,4 @@
-fickling==0.1.3
+fickling @ git+https://github.com/trailofbits/fickling.git@master
 huggingface_hub==0.23.5
 model_unpickler==0.1
 modelscan==0.8.1


### PR DESCRIPTION
Version has not been incremented so 0.1.3 does not include BadCalls in fickling.analysis. 

Alternatively __iniit__.py could increment the version number, but I didn't know if the benchmark code necessitated 0.1.4. 