### PR TITLE
ci: remove gh-action-sigstore-python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,3 @@ jobs:
 
       - name: publish
         uses: pypa/gh-action-pypi-publish@v1.12.4
-
-      - name: sign
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
-        with:
-          inputs: ./dist/*.tar.gz ./dist/*.whl
-          release-signing-artifacts: true


### PR DESCRIPTION
This signing step is now done internally
by gh-action-pypi-publish.