### PR TITLE
Fix flaky random ZIP creation in TestPolyglotModule

### DIFF
--- a/test/test_polyglot.py
+++ b/test/test_polyglot.py
@@ -54,6 +54,7 @@ def prepend_random_string(filename: Path, str_length=20):
 
 class TestPolyglotModule(unittest.TestCase):
     def setUp(self):
+        random.seed(42)  # Deterministic test data
         self.tmpdir = tempfile.TemporaryDirectory()
         tmppath = Path(self.tmpdir.name)
 


### PR DESCRIPTION
See #162 for context. I think the user got (un)lucky and the randomly generated ZIP file looked like a valid Pickle object with 2+ valid opcodes.