### PR TITLE
Redesign CLI with unified format-agnostic interface

### DIFF
--- a/fickling/constants.py
+++ b/fickling/constants.py
@@ -1,0 +1,4 @@
+# ClamAV-compatible exit codes for CI/CD integration
+EXIT_CLEAN = 0  # No issues found
+EXIT_UNSAFE = 1  # Potentially malicious content detected
+EXIT_ERROR = 2  # Scan error (parse failure, file not found, etc.)


### PR DESCRIPTION
## Summary

Replaces the nested subcommand approach with a flat, auto-detecting CLI interface:

- **Auto-detection**: The tool figures out if input is PyTorch, TorchScript, plain pickle, etc.
- **Flat commands**: No nesting, just `fickling <verb> <file>`
- **Backward compatible**: All existing flags (`--check-safety`, `--inject`, etc.) still work

## New CLI Commands

```bash
# Core commands (auto-detect format)
fickling FILE                           # Decompile any pickle/model
fickling check FILE                     # Safety check any format
fickling inject FILE -c CODE -o OUT     # Inject into any format
fickling info FILE                      # Show format + properties
fickling create-polyglot F1 F2 -o OUT   # Create polyglot file

# Backward compatible (still works)
fickling --check-safety FILE            # Same as 'fickling check FILE'
fickling --inject CODE FILE             # Legacy injection syntax
```

## Example Usage

```bash
# Just analyze a file (any format)
$ fickling model.pth
result0 = _rebuild_tensor_v2(...)

# Check if it's safe
$ fickling check model.pth
Detected format: PyTorch v1.3
No unsafe operations found.

# Get detailed info
$ fickling info model.pth
Format: PyTorch v1.3
Properties:
  is_torch_zip: true
  has_data_pkl: true
  ...

# Inject payload (works on any supported format)
$ fickling inject model.pth -c "print('pwned')" -o evil.pth
Detected format: PyTorch v1.3
Payload injected. Output: evil.pth
```

## Key Changes

| File | Change |
|------|--------|
| `fickling/loader.py` | Added `auto_load()` function for format detection |
| `fickling/cli.py` | Complete rewrite with flat command structure |
| `fickling/cli_pytorch.py` | **DELETED** - functionality absorbed into cli.py |
| `fickling/cli_polyglot.py` | **DELETED** - functionality absorbed into cli.py |
| `test/test_cli.py` | Updated tests for new interface |

## Design Decisions

1. **Auto-detection via `auto_load()`** - Tries PyTorch ZIP formats first (most common for ML), falls back to plain pickle
2. **Manual routing** - Uses `_get_first_positional()` to detect if first arg is a command vs file
3. **Separate parsers** - `_create_command_parser()` for new commands, `_create_legacy_parser()` for backward compat
4. **Unified handlers** - Same `_handle_check`, `_handle_inject`, etc. work for any format

## Test plan

- [x] All 20 CLI tests pass
- [x] All 41 tests in test_pickle.py and test_cli.py pass
- [x] Backward compatibility verified (--check-safety, --inject flags work)
- [x] Linting passes

Closes #101

🤖 Generated with [Claude Code](https://claude.ai/code)