### PR TITLE
Catch outbound network connection in pickles

### DIFF
--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -90,6 +90,12 @@ UNSAFE_IMPORTS: frozenset[str] = frozenset(
         "requests",
         "urllib",
         "urllib2",
+        "smtplib",
+        "imaplib",
+        "ftplib",
+        "poplib",
+        "telnetlib",
+        "nntplib",
         # IDE and dev tools
         "idlelib",
         "lib2to3",


### PR DESCRIPTION
Add `smtplib`, `imaplib`, `ftplib`, `poplib`, `telnetlib`, `nntplib` to `UNSAFE_IMPORTS` to catch outbound network connections. Thanks to @NucleiAv for the report.