### PR TITLE
Add AGENTS.md with vulnerability reporting guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,8 @@
 
 Please report vulnerabilities through [GitHub Security Advisories](https://github.com/trailofbits/fickling/security/advisories/new). Do not open public issues for security reports.
 
+Once a fix has been released, reports will be published as-is, with our assessment on top.
+
 ## What to include
 
 - A minimal reproducing test case using fickling's opcode API (`op.Proto`, `op.ShortBinUnicode`, `op.StackGlobal`, `op.Reduce`, etc.) or Python's `pickle` module. Do not submit raw byte strings.
@@ -13,7 +15,3 @@ Please report vulnerabilities through [GitHub Security Advisories](https://githu
 ## What is out of scope
 
 - **`UnusedVariables` bypasses.** This is an intentionally weak, supplementary heuristic. Bypassing it alone is not a meaningful finding.
-
-## Fixes
-
-Do not include suggested code fixes in reports unless they have been reviewed and approved by a maintainer first. If a fix is accepted, it will include a regression test in `test/test_bypasses.py` linked to the advisory.


### PR DESCRIPTION
Provide clear instructions for AI-assisted vulnerability reporters: require minimal test cases, pickle module payloads, non-offensive demonstrations, minimal impact sections, human-reviewed fixes only, and mark `UnusedVariables` bypasses as out of scope.