### PR TITLE
Fix OBJ opcode safety check bypass (GHSA-mxhj-88fx-4pcv)

### DIFF
--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -1602,11 +1602,16 @@ class Obj(Opcode):
         else:
             raise InterpretationError("Exhausted the stack while searching for a MarkObject!")
         kls = args.pop(0)
-        # TODO Verify paths for correctness
         if args or hasattr(kls, "__getinitargs__") or not isinstance(kls, type):
-            interpreter.stack.append(ast.Call(kls, args, []))
+            call = ast.Call(kls, args, [])
         else:
-            interpreter.stack.append(ast.Call(kls, kls, []))
+            # No args and kls is a plain type: CPython does kls.__new__(kls)
+            call = ast.Call(ast.Attribute(kls, "__new__", ast.Load()), [kls], [])
+        # OBJ calls can have global side effects, just like REDUCE.
+        # Persist the call to the AST via new_variable() so it remains visible
+        # to safety analysis even if the stack value is discarded by POP.
+        var_name = interpreter.new_variable(call)
+        interpreter.stack.append(ast.Name(var_name, ast.Load()))
 
 
 class ShortBinUnicode(DynamicLength, ConstantOpcode):
@@ -1673,10 +1678,17 @@ class NewObj(Opcode):
     def run(self, interpreter: Interpreter):
         args = interpreter.stack.pop()
         class_type = interpreter.stack.pop()
+        # CPython's NEWOBJ calls cls.__new__(cls, *args), not cls(*args).
+        # __new__ is allocation only (no __init__ side effects).
+        func = ast.Attribute(class_type, "__new__", ast.Load())
         if isinstance(args, ast.Tuple):
-            interpreter.stack.append(ast.Call(class_type, list(args.elts), []))
+            call = ast.Call(func, [class_type, *list(args.elts)], [])
         else:
-            interpreter.stack.append(ast.Call(class_type, [ast.Starred(args)], []))
+            call = ast.Call(func, [class_type, ast.Starred(args)], [])
+        # Persist the call to the AST via new_variable() so it remains visible
+        # to safety analysis even if the stack value is discarded by POP.
+        var_name = interpreter.new_variable(call)
+        interpreter.stack.append(ast.Name(var_name, ast.Load()))
 
 
 class NewObjEx(Opcode):
@@ -1686,10 +1698,16 @@ class NewObjEx(Opcode):
         kwargs = interpreter.stack.pop()
         args = interpreter.stack.pop()
         class_type = interpreter.stack.pop()
+        # CPython's NEWOBJ_EX calls cls.__new__(cls, *args, **kwargs), not cls(*args, **kwargs).
+        func = ast.Attribute(class_type, "__new__", ast.Load())
         if isinstance(args, ast.Tuple):
-            interpreter.stack.append(ast.Call(class_type, list(args.elts), kwargs))
+            call = ast.Call(func, [class_type, *list(args.elts)], kwargs)
         else:
-            interpreter.stack.append(ast.Call(class_type, [ast.Starred(args)], kwargs))
+            call = ast.Call(func, [class_type, ast.Starred(args)], kwargs)
+        # Persist the call to the AST via new_variable() so it remains visible
+        # to safety analysis even if the stack value is discarded by POP.
+        var_name = interpreter.new_variable(call)
+        interpreter.stack.append(ast.Name(var_name, ast.Load()))
 
 
 class BinPersId(Opcode):

--- a/test/test_bypasses.py
+++ b/test/test_bypasses.py
@@ -594,3 +594,26 @@ class TestBypasses(TestCase):
         )
         res = check_safety(pickled)
         self.assertGreater(res.severity, Severity.LIKELY_SAFE)
+
+    # https://github.com/trailofbits/fickling/security/advisories/GHSA-mxhj-88fx-4pcv
+    def test_obj_pop_call_invisibility(self):
+        """OBJ opcode calls discarded by POP must remain visible to safety analysis."""
+        pickled = Pickled(
+            [
+                op.Proto.create(4),
+                op.Mark(),
+                op.ShortBinUnicode("smtplib"),
+                op.ShortBinUnicode("SMTP"),
+                op.StackGlobal(),
+                op.ShortBinUnicode("127.0.0.1"),
+                op.Obj(),
+                op.Pop(),
+                op.NoneOpcode(),
+                op.Stop(),
+            ]
+        )
+        res = check_safety(pickled)
+        self.assertGreater(
+            res.severity,
+            Severity.LIKELY_SAFE,
+        )


### PR DESCRIPTION
`OBJ` pushed `ast.Call` directly onto the stack without persisting it to the AST via `new_variable()`. The result would be discarded by `POP` and would make it invisible to analysis passes.

Apply the same `new_variable()` pattern used by `Reduce.run()` to `Obj`, `NewObj`, and `NewObjEx` and fixed a few correctness issues. `NewObj` and `NewObjEx` now emit `cls.__new__(cls, *args)` to match CPython semantics, and the `Obj` no-args branch emits `kls.__new__(kls)` instead of the incorrect `kls(kls)`.

Thanks to @yash2998chhabria for reporting this vulnerability.