### PR TITLE
Expand UNSAFE_IMPORTS blocklist (GHSA-mhc9-48gj-9gp3)

### DIFF
--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -121,6 +121,36 @@ UNSAFE_IMPORTS: frozenset[str] = frozenset(
         "idlelib",
         # Parser generators (code execution)
         "lib2to3",
+        # Network services (constructors bind/listen)
+        "socketserver",
+        "xmlrpc",
+        # Process/thread control
+        "signal",
+        "_signal",
+        "threading",
+        "_thread",
+        # Database/file creation
+        "sqlite3",
+        "_sqlite3",
+        # File reading/enumeration
+        "fileinput",
+        "glob",
+        # Code compilation (writes .pyc files)
+        "compileall",
+        "py_compile",
+        # Memory mapping
+        "mmap",
+        # I/O multiplexing (enables network operations)
+        "select",
+        "selectors",
+        # Logging (can open files and network sockets via handlers)
+        "logging",
+        "syslog",
+        # Archive manipulation (can create/extract files)
+        "tarfile",
+        "zipfile",
+        # Shelve (opens database files)
+        "shelve",
     ]
 )
 


### PR DESCRIPTION
New modules: `socketserver`, `xmlrpc`, `signal`, `_signal`, `threading`, `_thread`, `sqlite3`, `_sqlite3`, `fileinput`, `glob`, `compileall`, `py_compile`, `mmap`, `select`, `selectors`, `logging`, `syslog`, `tarfile`, `zipfile`, `shelve`. Thanks to @yash2998chhabria for the report.