### PR TITLE
fix: walk result expression value to prevent false positive in UnusedVariables

### DIFF
--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -1243,14 +1243,17 @@ class Interpreter:
         defined: set[str] = set()
         assignments: dict[str, ast.Assign] = {}
         for statement in self.module_body:
-            # skip the last statement because it is always used
             if isinstance(statement, ast.Assign):
                 if (
                     len(statement.targets) == 1
                     and isinstance(statement.targets[0], ast.Name)
                     and statement.targets[0].id == "result"
                 ):
-                    # this is the return value of the program
+                    # this is the return value; don't define it, but still
+                    # walk its value to record variables it references
+                    for node in ast.walk(statement.value):
+                        if isinstance(node, ast.Name):
+                            used.add(node.id)
                     break
                 for target in statement.targets:
                     if isinstance(target, ast.Name):

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -194,6 +194,36 @@ class TestInterpreter(TestCase):
         test_unused_variables_results = check_safety(loaded).to_dict()
         self.assertEqual(test_unused_variables_results["severity"], "OVERTLY_MALICIOUS")
 
+    def test_unused_variables_no_false_positive_for_result_refs(self):
+        """Variables referenced only in the result expression should not be flagged as unused.
+
+        Regression test for https://github.com/trailofbits/fickling/issues/226
+        A REDUCE-created variable that is later referenced in the final result
+        tuple (via BINGET) was incorrectly reported as unused because the
+        result assignment's value was not walked for variable references.
+        """
+        # Craft a pickle: list([1,2,3]) via REDUCE (creates a variable),
+        # then reference it twice via memo to form the result tuple.
+        raw = (
+            b"\x80\x02"  # PROTO 2
+            b"c__builtin__\nlist\n"  # GLOBAL list
+            b"q\x00"  # BINPUT 0
+            b"]"  # EMPTY_LIST
+            b"(K\x01K\x02K\x03e"  # MARK 1 2 3 APPENDS
+            b"\x85"  # TUPLE1
+            b"R"  # REDUCE -> _var0 = list([1,2,3])
+            b"q\x01"  # BINPUT 1
+            b"h\x01"  # BINGET 1 (reference _var0)
+            b"\x86"  # TUPLE2 -> result = (_var0, _var0)
+            b"."  # STOP
+        )
+        loaded = Pickled.load(raw)
+        interpreter = Interpreter(loaded)
+        unused = interpreter.unused_variables()
+        # _var0 is used in the result tuple, so it must NOT be flagged
+        self.assertNotIn("_var0", unused, "Variable used in result expression was falsely flagged as unused")
+        self.assertEqual(len(unused), 0)
+
     @stacked_correctness_test([1, 2, 3, 4], [5, 6, 7, 8])
     def test_stacked_pickles(self):
         pass


### PR DESCRIPTION
## Summary

Fixes #226.

`unused_assignments()` breaks out of its loop upon encountering the `result = ...` assignment. However, it did so **before** walking the assignment's value for variable references. This caused any variable only referenced within the final result expression (e.g. via BINGET/memo-based sharing, or as part of a complex result tuple/dict) to be incorrectly flagged as unused.

## Root Cause

In `Interpreter.unused_assignments()` (fickle.py), the loop processed statements sequentially:

```python
if statement.targets[0].id == "result":
    break  # <-- exits WITHOUT walking statement.value
```

Variables referenced exclusively in the result expression were never added to the `used` set, so they appeared in `defined - used` and were falsely reported as suspicious.

## Fix

Before breaking, walk the result assignment's value to record all variable references:

```python
if statement.targets[0].id == "result":
    for node in ast.walk(statement.value):
        if isinstance(node, ast.Name):
            used.add(node.id)
    break
```

## Test

Added `test_unused_variables_no_false_positive_for_result_refs` which crafts a minimal pickle where a REDUCE-created variable is referenced only in the result tuple via BINGET. Without the fix, this variable is falsely flagged; with the fix, it correctly reports zero unused variables.

This directly reproduces the pattern seen in the scanpy pickle from #226, where variables created by `numpy.core.multiarray.scalar` REDUCE calls end up referenced only within result-level structures.