### PR TITLE
Expand UNSAFE_IMPORTS blocklist (GHSA-m6fh-58r7-x697)

### DIFF
--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -74,6 +74,7 @@ UNSAFE_IMPORTS: frozenset[str] = frozenset(
         "pty",
         "commands",  # Legacy Python 2 module
         "multiprocessing",
+        "_posixsubprocess",
         # Code execution/compilation
         "code",
         "codeop",
@@ -91,6 +92,7 @@ UNSAFE_IMPORTS: frozenset[str] = frozenset(
         "pkgutil",
         "zipimport",
         "gc",
+        "site",
         # Attribute access (getattr equivalent bypasses)
         "inspect",
         # Operator module bypasses
@@ -156,6 +158,7 @@ UNSAFE_IMPORTS: frozenset[str] = frozenset(
         "_signal",
         "threading",
         "_thread",
+        "atexit",
         # Database/file creation
         "sqlite3",
         "_sqlite3",


### PR DESCRIPTION
This blocks a direct command execution gadget with `_posixsubprocess`, a way to load local PTH with `site`, and potential exit hooks with `atexit`. Thanks to @reapermunky for the report!