### PR TITLE
Fix UnusedVariables false positive on result-referenced variables

### DIFF
--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -1304,7 +1304,14 @@ class Interpreter:
                     and isinstance(statement.targets[0], ast.Name)
                     and statement.targets[0].id == "result"
                 ):
-                    # this is the return value of the program
+                    # This is the return value of the program, so the assignment
+                    # itself is always considered used. We still need to walk its
+                    # value so that any variables it references are recorded as
+                    # used — otherwise a variable only referenced via the result
+                    # expression would be falsely flagged as unused (#226).
+                    for node in ast.walk(statement.value):
+                        if isinstance(node, ast.Name):
+                            used.add(node.id)
                     break
                 for target in statement.targets:
                     if isinstance(target, ast.Name):
@@ -1619,7 +1626,7 @@ class TupleOne(Opcode):
 
     def run(self, interpreter: Interpreter):
         stack_top = interpreter.stack.pop()
-        interpreter.stack.push(ast.Tuple((stack_top,), ast.Load()))
+        interpreter.stack.push(ast.Tuple([stack_top], ast.Load()))
 
 
 class TupleTwo(Opcode):
@@ -1628,7 +1635,7 @@ class TupleTwo(Opcode):
     def run(self, interpreter: Interpreter):
         arg2 = interpreter.stack.pop()
         arg1 = interpreter.stack.pop()
-        interpreter.stack.append(ast.Tuple((arg1, arg2), ast.Load()))
+        interpreter.stack.append(ast.Tuple([arg1, arg2], ast.Load()))
 
 
 class TupleThree(Opcode):
@@ -1638,7 +1645,7 @@ class TupleThree(Opcode):
         top = interpreter.stack.pop()
         mid = interpreter.stack.pop()
         bot = interpreter.stack.pop()
-        interpreter.stack.append(ast.Tuple((bot, mid, top), ast.Load()))
+        interpreter.stack.append(ast.Tuple([bot, mid, top], ast.Load()))
 
 
 class AddItems(Opcode):
@@ -1878,7 +1885,11 @@ class Tuple(StackSliceOpcode):
     name = "TUPLE"
 
     def run(self, interpreter: Interpreter, stack_slice: List[ast.expr]):
-        interpreter.stack.append(ast.Tuple(tuple(stack_slice), ast.Load()))
+        # `elts` must be a list, not a tuple, because `ast.walk` only
+        # recurses into list-typed fields — passing a tuple here would
+        # cause any variable referenced inside this tuple to be missed
+        # by `Interpreter.unused_assignments()` (#226).
+        interpreter.stack.append(ast.Tuple(list(stack_slice), ast.Load()))
 
 
 class Build(Opcode):
@@ -2238,7 +2249,11 @@ class Dict(Opcode):
                 f"Number of keys ({len(keys)}) and values ({len(values)}) for DICT do not match"
             )
 
-        interpreter.stack.append(ast.Dict(keys=reversed(keys), values=reversed(values)))
+        # `keys`/`values` must be lists, not reversed iterators, because
+        # `ast.walk` only recurses into list-typed fields — passing an
+        # iterator here would cause any variable referenced as a dict
+        # key or value to be missed by `unused_assignments()` (#226).
+        interpreter.stack.append(ast.Dict(keys=list(reversed(keys)), values=list(reversed(values))))
 
 
 PickledSequence = Sequence[Pickled]

--- a/test/test_benign_edge_cases.py
+++ b/test/test_benign_edge_cases.py
@@ -1,0 +1,195 @@
+"""False-positive prevention tests for the UnusedVariables heuristic.
+
+Regression coverage for https://github.com/trailofbits/fickling/issues/226:
+a variable that is referenced only inside the `result = ...` expression
+(the final assignment produced by `STOP`) must NOT be reported as unused.
+
+Before the fix, `Interpreter.unused_assignments()` broke out of its loop as
+soon as it encountered the `result` assignment without walking the value of
+that assignment for `ast.Name` references. That caused any variable that was
+only referenced via the result expression to be falsely flagged as unused.
+"""
+
+from pickle import dumps
+from unittest import TestCase
+
+import fickling.fickle as op
+from fickling.fickle import Interpreter, Pickled
+
+
+def _eval_call(payload: str) -> list[op.Opcode]:
+    """Opcodes that build `eval(payload)` on the stack ready for REDUCE."""
+    return [
+        op.Global.create("builtins", "eval"),
+        op.Mark(),
+        op.Unicode(payload),
+        op.Tuple(),
+    ]
+
+
+class TestUnusedVariablesResultReferences(TestCase):
+    # https://github.com/trailofbits/fickling/issues/226
+    def test_var_used_in_result_not_flagged(self):
+        """`result = _var0` references _var0, so _var0 is NOT unused."""
+        pickled = Pickled(
+            [
+                op.Proto.create(4),
+                *_eval_call("[1, 2, 3]"),
+                op.Reduce(),
+                op.Stop(),
+            ]
+        )
+        unused = Interpreter(pickled).unused_variables()
+        self.assertNotIn("_var0", unused)
+        self.assertEqual(len(unused), 0)
+
+    # https://github.com/trailofbits/fickling/issues/226
+    def test_var_used_multiple_times_in_result_via_memo(self):
+        """`result = (_var0, _var0)` built via BINGET — both refs count.
+
+        This mirrors the scanpy structure reported in #226: the variable
+        is assigned once and then referenced multiple times in the result
+        expression via the pickle memo (BINGET).
+        """
+        pickled = Pickled(
+            [
+                op.Proto.create(4),
+                *_eval_call("[1, 2, 3]"),
+                op.Reduce(),
+                # memo[0] = Name("_var0") (Reduce pushed this Name on the stack)
+                op.BinPut(0),
+                # push Name("_var0") twice via the memo, like scanpy's BINGET usage
+                op.BinGet(0),
+                op.BinGet(0),
+                op.TupleTwo(),
+                op.Stop(),
+            ]
+        )
+        unused = Interpreter(pickled).unused_variables()
+        self.assertNotIn("_var0", unused)
+        self.assertEqual(len(unused), 0)
+
+    # https://github.com/trailofbits/fickling/issues/226
+    def test_multiple_vars_used_in_result_not_flagged(self):
+        """`result = (_var0, _var1)` references both vars — neither is unused."""
+        pickled = Pickled(
+            [
+                op.Proto.create(4),
+                *_eval_call("[1, 2, 3]"),
+                op.Reduce(),
+                op.BinPut(0),
+                *_eval_call("[4, 5, 6]"),
+                op.Reduce(),
+                op.BinPut(1),
+                op.BinGet(0),
+                op.BinGet(1),
+                op.TupleTwo(),
+                op.Stop(),
+            ]
+        )
+        unused = Interpreter(pickled).unused_variables()
+        self.assertNotIn("_var0", unused)
+        self.assertNotIn("_var1", unused)
+        self.assertEqual(len(unused), 0)
+
+    # https://github.com/trailofbits/fickling/issues/226
+    def test_var_used_in_tuple_stack_slice_not_flagged(self):
+        """`result = (_var0, _var0, _var0, _var0)` built via TUPLE opcode.
+
+        The variable-arity TUPLE opcode (StackSliceOpcode) must build an
+        `ast.Tuple` whose `elts` is a list, otherwise `ast.walk` will not
+        recurse into the tuple elements and `_var0` will be falsely
+        flagged as unused.
+        """
+        pickled = Pickled(
+            [
+                op.Proto.create(4),
+                *_eval_call("[1, 2, 3]"),
+                op.Reduce(),
+                op.BinPut(0),
+                op.Mark(),
+                op.BinGet(0),
+                op.BinGet(0),
+                op.BinGet(0),
+                op.BinGet(0),
+                op.Tuple(),
+                op.Stop(),
+            ]
+        )
+        unused = Interpreter(pickled).unused_variables()
+        self.assertNotIn("_var0", unused)
+        self.assertEqual(len(unused), 0)
+
+    # https://github.com/trailofbits/fickling/issues/226
+    def test_var_used_in_dict_keys_not_flagged(self):
+        """`result = {_var0: "v1", _var0: "v2"}` built via DICT opcode.
+
+        The DICT opcode must build an `ast.Dict` whose `keys` and `values`
+        are lists (not `reversed()` iterators), otherwise `ast.walk` will
+        not recurse into them and `_var0` (used as a key) will be falsely
+        flagged as unused.
+        """
+        pickled = Pickled(
+            [
+                op.Proto.create(4),
+                *_eval_call("[1, 2, 3]"),
+                op.Reduce(),
+                op.BinPut(0),
+                op.Mark(),
+                op.BinGet(0),
+                op.Unicode("v1"),
+                op.BinGet(0),
+                op.Unicode("v2"),
+                op.Dict(),
+                op.Stop(),
+            ]
+        )
+        unused = Interpreter(pickled).unused_variables()
+        self.assertNotIn("_var0", unused)
+        self.assertEqual(len(unused), 0)
+
+    # Regression for the fix itself: ensure the fix does not over-correct
+    # and silently hide genuinely unused variables.
+    def test_genuinely_unused_var_still_flagged(self):
+        """`result = _var0` references _var0 but NOT _var1 — _var1 IS unused."""
+        pickled = Pickled(
+            [
+                op.Proto.create(4),
+                *_eval_call("[1, 2, 3]"),
+                op.Reduce(),
+                op.BinPut(0),
+                *_eval_call("[4, 5, 6]"),
+                op.Reduce(),
+                # discard _var1 from the stack; it is never referenced again
+                op.Pop(),
+                op.BinGet(0),
+                op.Stop(),
+            ]
+        )
+        unused = Interpreter(pickled).unused_variables()
+        self.assertNotIn("_var0", unused)
+        self.assertIn("_var1", unused)
+        self.assertEqual(len(unused), 1)
+
+    # End-to-end smoke test mirroring the original test_unused_variables
+    # scenario (where `use_output_as_unpickle_result=True` makes the eval
+    # result the unpickle output). After the fix, _var0 is correctly
+    # recognized as used by the result expression.
+    def test_insert_python_eval_replacing_result_no_false_positive(self):
+        from fickling.analysis import check_safety
+
+        pickled = dumps([1, 2, 3, 4])
+        loaded = Pickled.load(pickled)
+        self.assertIsInstance(loaded[-1], op.Stop)
+        loaded.insert_python_eval(
+            "[5, 6, 7, 8]", run_first=False, use_output_as_unpickle_result=True
+        )
+        interpreter = Interpreter(loaded)
+        unused = interpreter.unused_variables()
+        self.assertEqual(len(unused), 0)
+        # The eval is still overtly malicious — the fix only removes the
+        # false-positive unused-variable hit, not the eval detection.
+        results = check_safety(loaded).to_dict()
+        self.assertEqual(results["severity"], "OVERTLY_MALICIOUS")
+        detailed = results["detailed_results"]["AnalysisResult"]
+        self.assertNotIn("UnusedVariables", detailed)

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -184,8 +184,11 @@ class TestInterpreter(TestCase):
         pickled = dumps([1, 2, 3, 4])
         loaded = Pickled.load(pickled)
         self.assertIsInstance(loaded[-1], fpickle.Stop)
+        # run_first=True + use_output_as_unpickle_result=False leaves the
+        # eval result in _var0 while preserving the original [1,2,3,4] as
+        # the unpickle result, so _var0 is genuinely unused afterward.
         loaded.insert_python_eval(
-            "[5, 6, 7, 8]", run_first=False, use_output_as_unpickle_result=True
+            "[5, 6, 7, 8]", run_first=True, use_output_as_unpickle_result=False
         )
         interpreter = Interpreter(loaded)
         unused = interpreter.unused_variables()


### PR DESCRIPTION
## Problem

Fixes #226.

`fickling --check-safety` reports false-positive `UnusedVariables` hits on variables that **are** used — specifically, variables referenced only inside the `result = ...` expression (the final assignment produced by `STOP`). The scanpy pickle in the issue shows `_var16` flagged as unused even though it is referenced via `BINGET` inside the result tuple.

## Root cause

Two related bugs, same effect:

1. **`Interpreter.unused_assignments()` skips the result value.** Upon encountering the `result = ...` assignment it `break`s out of its loop without walking `statement.value` for `ast.Name` references. So any variable only referenced via the result expression is invisible to the heuristic.

2. **Four opcode implementations construct `ast.Tuple`/`ast.Dict` with non-list field values.** `ast.walk` only recurses into *list-typed* fields, not tuples or iterators. So even after fixing (1), variables nested inside these AST nodes would still be missed:
   - `TupleOne` / `TupleTwo` / `TupleThree` — `elts` was a `tuple`
   - `Tuple` (the variable-arity `TUPLE` opcode, `StackSliceOpcode`) — `elts` was `tuple(stack_slice)`
   - `Dict` (the `DICT` opcode) — `keys`/`values` were `reversed(...)` iterators

## Fix

- `unused_assignments()` now walks `statement.value` with `ast.walk` and adds every `ast.Name` id to `used` before the `break`.
- All four opcode implementations now pass `list` instead of `tuple`/`reversed()`.

## Scope

This is a **false-positive fix**, not a bypass fix. It sharpens the UnusedVariables heuristic's precision (fewer false alarms on legitimate pickles) without weakening any security guarantee: genuinely malicious eval/import calls are still flagged with the same severity. Per `SECURITY.md`, UnusedVariables *bypasses* remain out of scope; reducing false positives on used variables is a quality-of-output improvement and is in scope.

## Testing

- **New regression tests** in `test/test_benign_edge_cases.py` (7 tests):
  - `test_var_used_in_result_not_flagged` — `result = _var0` (simplest case, exercises fix #1)
  - `test_var_used_multiple_times_in_result_via_memo` — `result = (_var0, _var0)` via `BINGET` + `TupleTwo` (mirrors the scanpy structure from #226; exercises fix #2)
  - `test_multiple_vars_used_in_result_not_flagged` — `result = (_var0, _var1)` (guards against over-correction)
  - `test_var_used_in_tuple_stack_slice_not_flagged` — `result = (_var0, _var0, _var0, _var0)` via `TUPLE` opcode (exercises fix #3)
  - `test_var_used_in_dict_keys_not_flagged` — `result = {_var0: "v1", _var0: "v2"}` via `DICT` opcode (exercises fix #4)
  - `test_genuinely_unused_var_still_flagged` — `_var1` is genuinely unused; ensures the fix does not over-correct and hide real unused variables
  - `test_insert_python_eval_replacing_result_no_false_positive` — end-to-end smoke test via `check_safety()`; asserts the eval is still `OVERTLY_MALICIOUS` and `UnusedVariables` no longer appears in detailed results

- **Updated** `test/test_pickle.py::test_unused_variables` — the old test used `use_output_as_unpickle_result=True`, which makes `result = _var0` (so `_var0` IS used) yet asserted `_var0` was unused. That assertion codified the bug. Switched to `run_first=True, use_output_as_unpickle_result=False`, where `_var0` is genuinely unused (`result` is the original `[1,2,3,4]`). Severity remains `OVERTLY_MALICIOUS`.

Full suite: `118 passed` (was 116; +2 new tests for the StackSlice TUPLE and DICT cases). `ruff format` clean. `ruff check` reports only one pre-existing `B905` in `test_pickle.py:44` (unrelated to this change).

## AI Disclosure

This contribution was developed with assistance from an AI coding agent (Claude / TRAE IDE). Specifically:

- **What AI did**: helped diagnose the root cause (the `ast.walk` non-list-field limitation), wrote the opcode-level regression tests using fickling's `op.*` API, and ran a skeptical self-review pass.
- **What was human-verified**: the bug hypothesis was confirmed against a PoC reproducing the scanpy structure from #226; every fix point was manually traced against CPython's `ast.walk` semantics; the regression tests were empirically validated to fail without the fix and pass with it; the scope framing (false-positive fix vs. bypass) was manually checked against `SECURITY.md`.
- **Tool / model**: TRAE IDE with Claude (Anthropic).

I have reviewed every line of the diff and the tests, and I stand behind the correctness of this change.