### PR TITLE
Make analysis.Severity hashable (define __hash__ alongside __eq__)

### DIFF
--- a/fickling/analysis.py
+++ b/fickling/analysis.py
@@ -128,9 +128,6 @@ class Severity(Enum):
         return isinstance(other, Severity) and other.value == self.value
 
     def __hash__(self):
-        # Defining __eq__ above would otherwise set __hash__ to None, making
-        # Severity members unhashable and breaking their use as dict keys or
-        # set members. Restore hashability consistently with __eq__.
         return hash(self.value)
 
     def __ge__(self, other):

--- a/fickling/analysis.py
+++ b/fickling/analysis.py
@@ -127,6 +127,12 @@ class Severity(Enum):
     def __eq__(self, other):
         return isinstance(other, Severity) and other.value == self.value
 
+    def __hash__(self):
+        # Defining __eq__ above would otherwise set __hash__ to None, making
+        # Severity members unhashable and breaking their use as dict keys or
+        # set members. Restore hashability consistently with __eq__.
+        return hash(self.value)
+
     def __ge__(self, other):
         return self > other or self == other
 

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -17,3 +17,22 @@ class TestAnalysis(TestCase):
             ]
         )
         self.assertEqual(check_safety(pickled).severity, Severity.LIKELY_SAFE)
+
+    def test_severity_is_hashable(self):
+        # Regression: Severity defines __eq__, which nulls __hash__ unless a
+        # __hash__ is also defined. Without it, Severity members cannot be used
+        # as dict keys or set members -- a natural way to group/classify results
+        # (e.g. `severity in {Severity.OVERTLY_MALICIOUS, ...}`).
+        self.assertIsNotNone(type(Severity.LIKELY_SAFE).__hash__)
+
+        # set membership must work
+        bad = {Severity.OVERTLY_MALICIOUS, Severity.LIKELY_OVERTLY_MALICIOUS}
+        self.assertIn(Severity.OVERTLY_MALICIOUS, bad)
+        self.assertNotIn(Severity.LIKELY_SAFE, bad)
+
+        # every member must be usable as a dict key
+        by_severity = {sev: sev.severity for sev in Severity}
+        self.assertEqual(len(by_severity), len(list(Severity)))
+
+        # hashing stays consistent with __eq__
+        self.assertEqual(hash(Severity.SUSPICIOUS), hash(Severity.SUSPICIOUS))

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -17,22 +17,3 @@ class TestAnalysis(TestCase):
             ]
         )
         self.assertEqual(check_safety(pickled).severity, Severity.LIKELY_SAFE)
-
-    def test_severity_is_hashable(self):
-        # Regression: Severity defines __eq__, which nulls __hash__ unless a
-        # __hash__ is also defined. Without it, Severity members cannot be used
-        # as dict keys or set members -- a natural way to group/classify results
-        # (e.g. `severity in {Severity.OVERTLY_MALICIOUS, ...}`).
-        self.assertIsNotNone(type(Severity.LIKELY_SAFE).__hash__)
-
-        # set membership must work
-        bad = {Severity.OVERTLY_MALICIOUS, Severity.LIKELY_OVERTLY_MALICIOUS}
-        self.assertIn(Severity.OVERTLY_MALICIOUS, bad)
-        self.assertNotIn(Severity.LIKELY_SAFE, bad)
-
-        # every member must be usable as a dict key
-        by_severity = {sev: sev.severity for sev in Severity}
-        self.assertEqual(len(by_severity), len(list(Severity)))
-
-        # hashing stays consistent with __eq__
-        self.assertEqual(hash(Severity.SUSPICIOUS), hash(Severity.SUSPICIOUS))


### PR DESCRIPTION
## Summary

`analysis.Severity` is an `Enum` that defines `__eq__` but no `__hash__`. Per Python's data model, defining `__eq__` sets `__hash__` to `None`, so every `Severity` member is **unhashable** — even though enum members are normally hashable.

```python
from fickling.analysis import Severity

hash(Severity.LIKELY_SAFE)                            # TypeError: unhashable type: 'Severity'
Severity.OVERTLY_MALICIOUS in {Severity.SUSPICIOUS}   # TypeError: unhashable type: 'Severity'
{Severity.LIKELY_SAFE: "..."}                         # TypeError: unhashable type: 'Severity'
```

This breaks natural, idiomatic uses of the public `Severity` type — grouping results into a `dict` keyed by severity, or membership tests such as `results.severity in {Severity.OVERTLY_MALICIOUS, Severity.LIKELY_OVERTLY_MALICIOUS}`.

## Fix

Add a `__hash__` that is consistent with the value-based `__eq__`:

```python
def __hash__(self):
    return hash(self.value)
```

Two members compare equal iff they share `.value`, so hashing on `.value` preserves the hash/eq contract. Comparison and equality semantics are unchanged.

## Test

Adds `test_severity_is_hashable`: asserts `Severity` has a real `__hash__`, that set membership and dict-keying work across all members, and that hashing is stable. `pytest test/test_analysis.py` → passed; `ruff` clean.

## AI Disclosure

Used an AI assistant to help spot the missing `__hash__` and draft the fix + test; I verified the defect and confirmed the fix locally.
