### PR TITLE
Block private stdlib imports (GHSA-6ggj-6f2q-f7mx)

### DIFF
--- a/fickling/analysis.py
+++ b/fickling/analysis.py
@@ -265,17 +265,30 @@ class ResourceExhaustionAnalysis(Analysis):
 
 class NonStandardImports(Analysis):
     def analyze(self, context: AnalysisContext) -> Iterator[AnalysisResult]:
-        for node in context.pickled.non_standard_imports():
-            shortened = context.shorten_code(node)
-            if context.mark_reported(shortened):
-                yield AnalysisResult(
-                    Severity.LIKELY_UNSAFE,
-                    f"`{shortened}` imports a Python module that is not a part of "
-                    "the standard library; this can execute arbitrary code and is "
-                    "inherently unsafe",
-                    "NonStandardImports",
-                    trigger=shortened,
-                )
+        sources = (
+            (
+                context.pickled.non_standard_imports(),
+                "imports a Python module that is not a part of the standard "
+                "library; this can execute arbitrary code and is inherently unsafe",
+            ),
+            (
+                context.pickled.private_stdlib_imports(),
+                "imports a private, underscore-prefixed module of the Python "
+                "standard library; these are internal implementation details not "
+                "intended for direct use and never appear in legitimate pickles, "
+                "so this is treated as unsafe",
+            ),
+        )
+        for nodes, reason in sources:
+            for node in nodes:
+                shortened = context.shorten_code(node)
+                if context.mark_reported(shortened):
+                    yield AnalysisResult(
+                        Severity.LIKELY_UNSAFE,
+                        f"`{shortened}` {reason}",
+                        "NonStandardImports",
+                        trigger=shortened,
+                    )
 
 
 class UnsafeImportsML(Analysis):

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -85,6 +85,9 @@ UNSAFE_IMPORTS: frozenset[str] = frozenset(
         "exec",
         "eval",
         "doctest",
+        # Subinterpreters (execute arbitrary code in a fresh interpreter)
+        "_interpreters",  # 3.13+
+        "_xxsubinterpreters",  # <=3.12
         # Import manipulation
         "importlib",
         "_frozen_importlib",

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -264,8 +264,50 @@ SAFE_BUILTINS: frozenset[str] = frozenset(
 )
 
 
+# Exact (module, name) private-stdlib imports that legitimate serializers emit.
+PRIVATE_STDLIB_IMPORT_ALLOWLIST: frozenset[tuple[str, str]] = frozenset({("_codecs", "encode")})
+
+# Whole underscore-prefixed stdlib modules that any name may be imported from.
+# `__future__` is a dunder module (so is_private_or_dunder_stdlib_module flags it) whose
+# attributes are all inert feature-flag objects, so it can legitimately appear in
+# a pickle (e.g. what `pickle.dumps(__future__.annotations)` emits).
+PRIVATE_STDLIB_MODULE_ALLOWLIST: frozenset[str] = frozenset({"__future__"})
+
+
 def is_std_module(module_name: str) -> bool:
     return module_name in BUILTIN_STDLIB_MODULE_NAMES
+
+
+def is_private_or_dunder_stdlib_module(name: str) -> bool:
+    """A stdlib module with a leading underscore (`_socket`, `_pickle`,
+    `__future__`, …): internal or non-public, so it should never appear in a
+    pickle. Benign exceptions are handled in _is_allowed_private_import.
+    """
+    return name.startswith("_") and name in BUILTIN_STDLIB_MODULE_NAMES
+
+
+def import_name_components(node: ast.Import | ast.ImportFrom) -> Iterator[str]:
+    """Yield every dotted component of an import's module and imported names.
+
+    Pickle resolves dotted names, so every component of the module and of each
+    imported name is independently reachable (see GHSA-5j3x-jp52-966f).
+    """
+    if isinstance(node, ast.ImportFrom) and node.module:
+        yield from node.module.split(".")
+    for alias in node.names:
+        yield from alias.name.split(".")
+
+
+def _is_allowed_private_import(node: ast.Import | ast.ImportFrom) -> bool:
+    # Exact-shape match only: dotted modules (`foo._codecs`) and dotted names
+    # (`_codecs.encode.<x>`, `__future__._ssl.<x>`) never match.
+    if not isinstance(node, ast.ImportFrom) or node.module is None or len(node.names) != 1:
+        return False
+    name = node.names[0].name
+    # A whole-module allowlist entry permits any simple (non-dotted) name.
+    if node.module in PRIVATE_STDLIB_MODULE_ALLOWLIST and "." not in name:
+        return True
+    return (node.module, name) in PRIVATE_STDLIB_IMPORT_ALLOWLIST
 
 
 def extract_identifier_from_ast_node(
@@ -649,11 +691,18 @@ class ASTProperties(ast.NodeVisitor):
             isinstance(node, ast.ImportFrom)
             and node.module is not None
             and is_std_module(node.module)
+            and (
+                not is_private_or_dunder_stdlib_module(node.module)
+                or _is_allowed_private_import(node)
+            )
         ):
             self.likely_safe_imports |= {
                 n.name
                 for n in node.names
-                if not any(c in UNSAFE_IMPORTS for c in n.name.split("."))
+                if not any(
+                    c in UNSAFE_IMPORTS or is_private_or_dunder_stdlib_module(c)
+                    for c in n.name.split(".")
+                )
             }
 
     def visit_Import(self, node: ast.Import):
@@ -1129,23 +1178,11 @@ on the Pickled object instead"""
         )
 
     def unsafe_imports(self) -> Iterator[ast.Import | ast.ImportFrom]:
-        def is_unsafe(dotted: str) -> bool:
-            return any(c in UNSAFE_IMPORTS for c in dotted.split("."))
-
         for node in self.properties.imports:
-            if isinstance(node, ast.ImportFrom):
-                if node.module and is_unsafe(node.module):
-                    yield node
-                elif any(is_unsafe(n.name) for n in node.names):
-                    yield node
-                elif "eval" in (n.name for n in node.names):
-                    yield node
-            else:
-                # ast.Import: check if any imported module is unsafe
-                if any(is_unsafe(alias.name) for alias in node.names):
-                    yield node
-                elif "eval" in (alias.name for alias in node.names):
-                    yield node
+            if any(c in UNSAFE_IMPORTS for c in import_name_components(node)):
+                yield node
+            elif "eval" in (n.name for n in node.names):
+                yield node
 
     def non_standard_imports(self) -> Iterator[ast.Import | ast.ImportFrom]:
         for node in self.properties.imports:
@@ -1158,6 +1195,13 @@ on the Pickled object instead"""
                 # import x, y, z - check if any name is non-standard
                 if any(not is_std_module(alias.name) for alias in node.names):
                     yield node
+
+    def private_stdlib_imports(self) -> Iterator[ast.Import | ast.ImportFrom]:
+        for node in self.properties.imports:
+            if _is_allowed_private_import(node):
+                continue
+            if any(is_private_or_dunder_stdlib_module(c) for c in import_name_components(node)):
+                yield node
 
     @property
     def ast(self) -> ast.Module:

--- a/test/test_bypasses.py
+++ b/test/test_bypasses.py
@@ -727,6 +727,28 @@ class TestBypasses(TestCase):
             "MLAllowlist did not produce a finding for `from ast import parse`",
         )
 
+    # https://github.com/trailofbits/fickling/security/advisories/GHSA-6ggj-6f2q-f7mx
+    def test_private_stdlib_interpreters_blocklisted(self):
+        for module in ("_interpreters", "_xxsubinterpreters"):
+            with self.subTest(module=module):
+                pickled = Pickled(
+                    [
+                        op.Proto.create(4),
+                        op.ShortBinUnicode(module),
+                        op.ShortBinUnicode("create"),
+                        op.StackGlobal(),
+                        op.EmptyTuple(),
+                        op.Reduce(),
+                        op.Stop(),
+                    ]
+                )
+                res = check_safety(pickled)
+                self.assertEqual(
+                    res.detailed_results()["AnalysisResult"].get("UnsafeImports"),
+                    f"from {module} import create",
+                )
+                self.assertGreaterEqual(res.severity, Severity.LIKELY_OVERTLY_MALICIOUS)
+
 
 class TestUnsafeModuleCoverage(TestCase):
     """Verify every entry in UNSAFE_MODULES and UNSAFE_IMPORTS triggers detection."""

--- a/test/test_bypasses.py
+++ b/test/test_bypasses.py
@@ -472,6 +472,9 @@ class TestBypasses(TestCase):
         )
         res = check_safety(pickled)
         self.assertGreater(res.severity, Severity.LIKELY_SAFE)
+        detailed = res.detailed_results()["AnalysisResult"]
+        self.assertEqual(detailed.get("UnsafeImports"), "from _operator import methodcaller")
+        self.assertEqual(detailed.get("NonStandardImports"), "from _operator import methodcaller")
 
     # https://github.com/mmaitre314/picklescan/security/advisories/GHSA-m273-6v24-x4m4
     def test_distutils_write_file(self):
@@ -748,6 +751,39 @@ class TestBypasses(TestCase):
                     f"from {module} import create",
                 )
                 self.assertGreaterEqual(res.severity, Severity.LIKELY_OVERTLY_MALICIOUS)
+
+    # `_codecs.encode` and `__future__` are the only private/dunder stdlib shapes
+    # kept off NonStandardImports: numpy emits `_codecs.encode(data, 'latin1')`
+    # when reconstructing arrays, and `__future__` exposes only inert feature
+    # flags. Detection of non-allowlisted private modules is covered by
+    # test_operator_methodcaller and test_private_stdlib_interpreters_blocklisted.
+    def test_private_stdlib_allowlist(self):
+        def import_global(module, name):
+            return Pickled(
+                [
+                    op.Proto.create(4),
+                    op.ShortBinUnicode(module),
+                    op.ShortBinUnicode(name),
+                    op.StackGlobal(),
+                    op.Stop(),
+                ]
+            )
+
+        for module, name in (("_codecs", "encode"), ("__future__", "annotations")):
+            with self.subTest(allowed=f"{module}.{name}"):
+                res = check_safety(import_global(module, name))
+                self.assertNotIn(
+                    "NonStandardImports", res.detailed_results().get("AnalysisResult", {})
+                )
+                self.assertEqual(res.severity, Severity.LIKELY_SAFE)
+
+        # Anti-widening: a dotted name under an allowlisted module is not allowlisted.
+        res = check_safety(import_global("__future__", "_ssl.RAND_bytes"))
+        self.assertEqual(
+            res.detailed_results()["AnalysisResult"].get("NonStandardImports"),
+            "from __future__ import _ssl.RAND_bytes",
+        )
+        self.assertGreaterEqual(res.severity, Severity.LIKELY_UNSAFE)
 
 
 class TestUnsafeModuleCoverage(TestCase):


### PR DESCRIPTION
The subinterpreter modules expose `create`/`run_string`, which execute arbitrary Python source in a fresh interpreter within the same process. Fixed in the first commit by blocklisting both names `_interpreters` and `_xxsubinterpreters` to cover all Python versions. Thanks to @revanthmeesala for this report!

The second commit broadens that by blocking stdlib imports with an underscore prefix for private and dunder modules. An allowlist still lets `_codecs.encode` and `__future__` pass for now.