### PR TITLE
Fix UnusedVariables false positive on SETITEM keys

### DIFF
--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -1342,25 +1342,34 @@ class Interpreter:
             self.run()
         used: set[str] = set()
         assignments: dict[str, ast.Assign] = {}
+
+        def record_uses(node: ast.AST) -> None:
+            for child in ast.walk(node):
+                if isinstance(child, ast.Name):
+                    used.add(child.id)
+
         for statement in self.module_body:
             if isinstance(statement, ast.Assign):
                 for target in statement.targets:
-                    if isinstance(target, ast.Name):
-                        if target.id == self.result_variable:
-                            # This is the return value of the program, which the program itself
-                            # never uses, so do not record it as defined.
-                            continue
-                        if target.id in assignments:
-                            # This should never happen, since Fickling constructs the AST.
-                            sys.stderr.write(
-                                f"Warning: Duplicate declaration of variable {target.id}\n"
-                            )
-                        assignments[target.id] = statement
+                    if not isinstance(target, ast.Name):
+                        # A compound target is a *use* of every name it mentions, not a
+                        # definition: in the `d[k] = v` that `SETITEM` emits, the target reads
+                        # both `d` and `k`. (`v` is the value, scanned below.)
+                        record_uses(target)
+                        continue
+                    if target.id == self.result_variable:
+                        # This is the return value of the program, which the program itself
+                        # never uses, so do not record it as defined.
+                        continue
+                    if target.id in assignments:
+                        # This should never happen, since Fickling constructs the AST.
+                        sys.stderr.write(
+                            f"Warning: Duplicate declaration of variable {target.id}\n"
+                        )
+                    assignments[target.id] = statement
                 statement = statement.value
             if statement is not None:
-                for node in ast.walk(statement):
-                    if isinstance(node, ast.Name):
-                        used.add(node.id)
+                record_uses(statement)
         return {name: asmt for name, asmt in assignments.items() if name not in used}
 
     def unused_variables(self) -> frozenset[str]:

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -224,6 +224,32 @@ class TestInterpreter(TestCase):
         self.assertEqual(len(Interpreter(pickled).unused_variables()), 0)
         self.assertEqual(check_safety(pickled).to_dict()["severity"], "LIKELY_SAFE")
 
+    def test_variable_used_only_in_an_assignment_target(self):
+        # `unused_assignments()` must scan compound assignment targets: `SETITEM` on a non-empty
+        # dict emits `_var1[_var0] = '2'`, so both the dict and the key are used from the target
+        # rather than from the value. The first `SETITEM` below takes the empty-dict branch that
+        # builds an `ast.Dict`; only the second one emits the subscript assignment.
+        pickled = Pickled(
+            [
+                fpickle.Proto.create(2),
+                fpickle.EmptyDict(),
+                fpickle.ShortBinUnicode("a"),
+                fpickle.ShortBinUnicode("1"),
+                fpickle.SetItem(),  # _var1 = {'a': '1'}
+                fpickle.ShortBinUnicode("decimal"),
+                fpickle.ShortBinUnicode("Decimal"),
+                fpickle.StackGlobal(),
+                fpickle.ShortBinUnicode("1"),
+                fpickle.TupleOne(),
+                fpickle.Reduce(),  # _var0 = Decimal('1')
+                fpickle.ShortBinUnicode("2"),
+                fpickle.SetItem(),  # _var1[_var0] = '2'
+                fpickle.Stop(),
+            ]
+        )
+        self.assertEqual(len(Interpreter(pickled).unused_variables()), 0)
+        self.assertEqual(check_safety(pickled).to_dict()["severity"], "LIKELY_SAFE")
+
     @stacked_correctness_test([1, 2, 3, 4], [5, 6, 7, 8])
     def test_stacked_pickles(self):
         pass


### PR DESCRIPTION
`unused_assignments()` discarded statement.targets before walking for uses, so a variable whose only use was a compound assignment target looked unused. `SETITEM` on a non-empty dict emits `d[k] = v`, which reads both `d` and `k` from the target, so a `Decimal` used only as a dict key scored SUSPICIOUS.

Non-`Name` targets are now scanned rather than dropped. Third in the same family as the two false positives fixed in #301.