### PR TITLE
Bump ruff to v0.16.0 and clear the lint ignore backlog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.16.0
     hooks:
       # Lint with auto-fix (run before formatter)
       - id: ruff-check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,15 +60,17 @@ uv run pytest -q test/test_bypasses.py     # just bypass regression tests
 
 ```python
 def test_example_bypass(self):
-    pickled = Pickled([
-        op.Proto.create(4),
-        op.ShortBinUnicode("dangerous_module"),
-        op.ShortBinUnicode("dangerous_func"),
-        op.StackGlobal(),
-        op.EmptyTuple(),
-        op.Reduce(),
-        op.Stop(),
-    ])
+    pickled = Pickled(
+        [
+            op.Proto.create(4),
+            op.ShortBinUnicode("dangerous_module"),
+            op.ShortBinUnicode("dangerous_func"),
+            op.StackGlobal(),
+            op.EmptyTuple(),
+            op.Reduce(),
+            op.Stop(),
+        ]
+    )
     self.assertGreater(check_safety(pickled).severity, Severity.LIKELY_SAFE)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,13 @@ Static analyzer, decompiler, and bytecode rewriter for Python pickle serializati
 make dev            # uv sync --all-extras
 make test           # pytest --cov=fickling test/ + coverage report
 make test-quick     # pytest -q test/ (no coverage)
-make lint           # ruff format --check + ruff check + mypy
+make lint           # ruff format --check + ruff check + ty (advisory)
 make format         # ruff check --fix + ruff format
 ```
 
-CI uses `ty check fickling/` for type checking (not mypy). Run `uv run ty check fickling/` locally to match CI.
+`make lint` mirrors `lint.yml`: formatting is checked over the whole repo
+(including Python snippets in Markdown), and `ty` is advisory, so a non-zero
+`ty` exit does not fail the target. Use `make typecheck` to have it fail.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
 PY_MODULE := fickling
 
-ALL_PY_SRCS := $(shell find $(PY_MODULE) -name '*.py') \
-	$(shell find test -name '*.py') \
-	$(shell find example -name '*.py')
-
 .PHONY: all
 all:
 	@echo "Run my targets individually!"
@@ -14,14 +10,15 @@ dev:
 
 .PHONY: lint
 lint:
-	uv run ruff format --check $(ALL_PY_SRCS)
+	uv run ruff format --check .
 	uv run ruff check $(PY_MODULE)
-	uv run mypy $(PY_MODULE)
+	# advisory until the annotations are fixed, matching lint.yml
+	-uv run ty check $(PY_MODULE)
 
 .PHONY: format
 format:
 	uv run ruff check --fix $(PY_MODULE)
-	uv run ruff format $(ALL_PY_SRCS)
+	uv run ruff format .
 
 .PHONY: test
 test:
@@ -34,7 +31,7 @@ test-quick:
 
 .PHONY: typecheck
 typecheck:
-	uv run mypy $(PY_MODULE)
+	uv run ty check $(PY_MODULE)
 
 .PHONY: dist
 dist:
@@ -42,7 +39,7 @@ dist:
 
 .PHONY: clean
 clean:
-	rm -rf dist/ build/ *.egg-info .coverage .pytest_cache .mypy_cache .ruff_cache
+	rm -rf dist/ build/ *.egg-info .coverage .pytest_cache .ty_cache .ruff_cache
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	find . -type f -name "*.pyc" -delete
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ library that uses `pickle`**:
 
 ```python
 import fickling
+
 # This sets global hooks on pickle
 fickling.hook.activate_safe_ml_environment()
 ```
@@ -68,10 +69,12 @@ fickling.hook.deactivate_safe_ml_environment()
 It is possible that the models you are using contain imports that aren't allowed by Fickling. If you still want to load the model, you can simply allow additional imports for your specific use-case with the `also_allow` argument:
 
 ```python
-fickling.hook.activate_safe_ml_environment(also_allow=[
-    "some.import",
-    "another.allowed.import",
-])
+fickling.hook.activate_safe_ml_environment(
+    also_allow=[
+        "some.import",
+        "another.allowed.import",
+    ]
+)
 ```
 
 **Important**: You should always make sure that manually added imports are actually safe and can not enable attackers to execute arbitrary code. If you are unsure on how to do that, you can open an issue on Fickling's Github repository that indicates the imports/models in question, and our team can review them and include them in the allow list if possible.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ To enable Fickling security checks simply run the following lines once in your p
 
 ```python
 import fickling
+
 # This sets global hooks on pickle
 fickling.hook.activate_safe_ml_environment()
 ```
@@ -67,10 +68,12 @@ fickling.hook.deactivate_safe_ml_environment()
 It is possible that the models you are using contain imports that aren't allowed by Fickling. If you still want to load the model, you can simply allow additional imports for your specific use-case with the `also_allow` argument:
 
 ```python
-fickling.hook.activate_safe_ml_environment(also_allow=[
-    "some.import",
-    "another.allowed.import",
-])
+fickling.hook.activate_safe_ml_environment(
+    also_allow=[
+        "some.import",
+        "another.allowed.import",
+    ]
+)
 ```
 
 **Important**: You should always make sure that manually added imports are actually safe and can not enable attackers to execute arbitrary code. If you are unsure on how to do that, you can open an issue on Fickling's Github repository that indicates the imports/models in question, and our team can review them and include them in the allow list if possible.

--- a/example/context_manager.py
+++ b/example/context_manager.py
@@ -9,7 +9,6 @@ with open("safe.pkl", "wb") as file:
 
 # This context manager scans the file
 # It will halt unpickling for files of high severity
-with fickling.check_safety():
-    with open("safe.pkl", "rb") as file:
-        safe_data = pickle.load(file)
-        print(safe_data)
+with fickling.check_safety(), open("safe.pkl", "rb") as file:
+    safe_data = pickle.load(file)
+    print(safe_data)

--- a/example/fault_injection.py
+++ b/example/fault_injection.py
@@ -8,10 +8,10 @@ Note you may need to run `pip install pytorchfi`
 import pickle
 
 import torch
-import torchvision.models as models
 from pytorchfi.core import fault_injection
+from torchvision import models
 
-import fickling.analysis as analysis
+from fickling import analysis
 from fickling.fickle import Pickled
 
 # Load AlexNet

--- a/example/fault_injection.py
+++ b/example/fault_injection.py
@@ -28,7 +28,7 @@ channels = 3
 
 random_image = torch.rand((batch_size, channels, height, width))
 output = model(random_image)
-proper_label = list(torch.argmax(output, dim=1))[0].item()
+proper_label = torch.argmax(output, dim=1)[0].item()
 print("Error-free label:", proper_label)
 
 # Fickle the safe model
@@ -53,7 +53,7 @@ injected_model = injected_model.declare_neuron_fi(
 )
 
 injected_output = injected_model(random_image)
-injected_label = list(torch.argmax(injected_output, dim=1))[0].item()
+injected_label = torch.argmax(injected_output, dim=1)[0].item()
 print("Injected Label:", injected_label)
 
 # Fickle the model with the fault injection

--- a/example/identify_pytorch_file.py
+++ b/example/identify_pytorch_file.py
@@ -1,7 +1,7 @@
 import torch
-import torchvision.models as models
+from torchvision import models
 
-import fickling.polyglot as polyglot
+from fickling import polyglot
 
 model = models.mobilenet_v2()
 torch.save(model, "mobilenet.pth")

--- a/example/inject_mobilenet.py
+++ b/example/inject_mobilenet.py
@@ -13,7 +13,7 @@ print("Running eval()")
 model.eval()
 print("Finished running eval()\n\n")
 
-payload = '''exec("""type(model).eval = eval('lambda model: print("!!!!We can run whatever custom Python code we want to!!!!")')""")'''  # noqa
+payload = '''exec("""type(model).eval = eval('lambda model: print("!!!!We can run whatever custom Python code we want to!!!!")')""")'''
 fickled_model = Pickled.load(pickle.dumps(model))
 
 # Use the insert_python_exec() method to inject the payload

--- a/example/inject_mobilenet.py
+++ b/example/inject_mobilenet.py
@@ -1,6 +1,6 @@
 import pickle
 
-import torchvision.models as models
+from torchvision import models
 
 import fickling
 from fickling.fickle import Pickled

--- a/example/inject_pytorch.py
+++ b/example/inject_pytorch.py
@@ -1,5 +1,5 @@
 import torch
-import torchvision.models as models
+from torchvision import models
 
 from fickling.pytorch import PyTorchModelWrapper
 

--- a/example/numpy_poc.py
+++ b/example/numpy_poc.py
@@ -5,7 +5,7 @@ import pickle
 
 import numpy
 
-import fickling.analysis as analysis
+from fickling import analysis
 from fickling.fickle import Pickled
 
 

--- a/example/pytorch_poc.py
+++ b/example/pytorch_poc.py
@@ -9,8 +9,8 @@ https://pytorch.org/tutorials/beginner/saving_loading_models.html
 from pathlib import Path
 
 import torch
-import torch.nn.functional as F
-from torch import nn, optim
+import torch.nn.functional as F  # noqa: N812
+from torch import nn
 
 from fickling.pytorch import PyTorchModelWrapper
 

--- a/example/pytorch_poc.py
+++ b/example/pytorch_poc.py
@@ -32,8 +32,7 @@ class TheModelClass(nn.Module):
         x = x.view(-1, 16 * 5 * 5)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
-        x = self.fc3(x)
-        return x
+        return self.fc3(x)
 
 
 if __name__ == "__main__":

--- a/example/trace_binary.py
+++ b/example/trace_binary.py
@@ -1,7 +1,7 @@
 import io
 from ast import unparse
 
-import fickling.tracing as tracing
+from fickling import tracing
 from fickling.fickle import Interpreter, Pickled
 
 # Grab mystery binary object

--- a/example/trace_binary.py
+++ b/example/trace_binary.py
@@ -6,7 +6,7 @@ from fickling.fickle import Interpreter, Pickled
 
 # Grab mystery binary object
 # This comes from https://github.com/maurosoria/dirsearch/issues/1073
-mystery = b"\x80\x04\x95E\x00\x00\x00\x00\x00\x00\x00(\x8c\x08builtins\x8c\x07getattr\x93\x8c\x08builtins\x8c\n__import__\x93\x8c\x02os\x85R\x8c\x06system\x86R\x8c\x02id\x85R1N."  # noqa
+mystery = b"\x80\x04\x95E\x00\x00\x00\x00\x00\x00\x00(\x8c\x08builtins\x8c\x07getattr\x93\x8c\x08builtins\x8c\n__import__\x93\x8c\x02os\x85R\x8c\x06system\x86R\x8c\x02id\x85R1N."
 binary = io.BytesIO(mystery)
 
 # Load using fickling

--- a/fickling/__main__.py
+++ b/fickling/__main__.py
@@ -1,4 +1,6 @@
+import sys
+
 from .cli import main
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/fickling/analysis.py
+++ b/fickling/analysis.py
@@ -6,6 +6,7 @@ from ast import Import, ImportFrom, unparse
 from collections import defaultdict
 from collections.abc import Iterable, Iterator
 from enum import Enum
+from typing import ClassVar
 
 from fickling.exception import ResourceExhaustionError
 from fickling.fickle import (
@@ -171,7 +172,7 @@ class AnalysisResult:
 
 
 class Analysis(ABC):
-    ALL: list[Analysis] = []
+    ALL: ClassVar[list[Analysis]] = []
 
     def __init_subclass__(cls, *, register: bool = True, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -219,16 +220,15 @@ class DuplicateProtoAnalysis(Analysis):
 class MisplacedProtoAnalysis(Analysis):
     def analyze(self, context: AnalysisContext) -> Iterator[AnalysisResult]:
         for i, opcode in enumerate(context.pickled):
-            if isinstance(opcode, Proto):
-                if opcode.version >= 2 and i > 0:
-                    yield AnalysisResult(
-                        Severity.LIKELY_UNSAFE,
-                        f"The protocol version is {opcode.version}, but the PROTO opcode is not "
-                        f"the first opcode in the pickle, as required for versions 2 and later; "
-                        f"this may be indicative of a tampered pickle",
-                        "MisplacedProtoAnalysis",
-                        trigger=str(opcode.version),
-                    )
+            if isinstance(opcode, Proto) and opcode.version >= 2 and i > 0:
+                yield AnalysisResult(
+                    Severity.LIKELY_UNSAFE,
+                    f"The protocol version is {opcode.version}, but the PROTO opcode is not "
+                    f"the first opcode in the pickle, as required for versions 2 and later; "
+                    f"this may be indicative of a tampered pickle",
+                    "MisplacedProtoAnalysis",
+                    trigger=str(opcode.version),
+                )
 
 
 class InvalidOpcode(Analysis):
@@ -295,7 +295,7 @@ class UnsafeImportsML(Analysis):
     # ML-specific unsafe modules only; general-purpose modules (os, subprocess,
     # socket, pickle, etc.) are already covered by fickle.py's UNSAFE_IMPORTS
     # frozenset and caught by the UnsafeImports analysis.
-    UNSAFE_MODULES = {
+    UNSAFE_MODULES: ClassVar[dict[str, str]] = {
         "torch.hub": (
             "This module can load untrusted files from the web, exposing the system to "
             "arbitrary code execution."
@@ -312,7 +312,7 @@ class UnsafeImportsML(Analysis):
     # modules are blocked at the module level by fickle.py's UNSAFE_IMPORTS.
     # _io/io are kept here because blocking the entire io module would flag
     # io.BytesIO which is ubiquitous in ML model loading.
-    UNSAFE_IMPORTS = {
+    UNSAFE_IMPORTS: ClassVar[dict[str, dict[str, str]]] = {
         "torch": {
             "load": "This function can load untrusted files and code from arbitrary web sources.",
             "compile": "This function can compile and execute arbitrary code.",
@@ -397,7 +397,7 @@ class UnsafeImportsML(Analysis):
 
 
 class BadCalls(Analysis):
-    BAD_CALLS = ["exec", "eval", "compile", "open"]
+    BAD_CALLS: ClassVar[list[str]] = ["exec", "eval", "compile", "open"]
 
     def analyze(self, context: AnalysisContext) -> Iterator[AnalysisResult]:
         for node in context.pickled.properties.calls:
@@ -642,7 +642,7 @@ class AnalysisResults:
 
     def to_dict(self, verbosity: Severity = Severity.POSSIBLY_UNSAFE):
         analysis_message = self.to_string(verbosity)
-        severity_data = {
+        return {
             "severity": self.severity.name,
             "analysis": (
                 analysis_message
@@ -653,7 +653,6 @@ class AnalysisResults:
             ),
             "detailed_results": self.detailed_results(),
         }
-        return severity_data
 
 
 def check_safety(

--- a/fickling/analysis.py
+++ b/fickling/analysis.py
@@ -26,6 +26,12 @@ from fickling.fickle import (
     Put,
 )
 
+# Calls that are almost never legitimate in a pickle. These are matched against the
+# unparsed call expression, so the opening parenthesis is part of every entry.
+OVERTLY_BAD_CALL_PREFIXES: frozenset[str] = frozenset(
+    {"eval(", "exec(", "compile(", "open(", "_run_code(", "execWrapper("}
+)
+
 
 class AnalyzerMeta(type):
     _DEFAULT_INSTANCE: Analyzer | None = None
@@ -268,15 +274,19 @@ class NonStandardImports(Analysis):
         sources = (
             (
                 context.pickled.non_standard_imports(),
-                "imports a Python module that is not a part of the standard "
-                "library; this can execute arbitrary code and is inherently unsafe",
+                (
+                    "imports a Python module that is not a part of the standard "
+                    "library; this can execute arbitrary code and is inherently unsafe"
+                ),
             ),
             (
                 context.pickled.private_stdlib_imports(),
-                "imports a private, underscore-prefixed module of the Python "
-                "standard library; these are internal implementation details not "
-                "intended for direct use and never appear in legitimate pickles, "
-                "so this is treated as unsafe",
+                (
+                    "imports a private, underscore-prefixed module of the Python "
+                    "standard library; these are internal implementation details not "
+                    "intended for direct use and never appear in legitimate pickles, "
+                    "so this is treated as unsafe"
+                ),
             ),
         )
         for nodes, reason in sources:
@@ -349,9 +359,7 @@ class UnsafeImportsML(Analysis):
     def analyze(self, context: AnalysisContext) -> Iterator[AnalysisResult]:
         for node in context.pickled.properties.imports:
             shortened = context.shorten_code(node)
-            all_modules = [
-                node.module.rsplit(".", i)[0] for i in range(0, node.module.count(".") + 1)
-            ]
+            all_modules = [node.module.rsplit(".", i)[0] for i in range(node.module.count(".") + 1)]
             for module_name in all_modules:
                 if module_name in self.UNSAFE_MODULES:
                     # Special handling for builtins - check specific function names
@@ -422,14 +430,7 @@ class OvertlyBadEvals(Analysis):
                 # standard library, it's probably okay
                 continue
             shortened = context.shorten_code(node)
-            if (
-                shortened.startswith("eval(")
-                or shortened.startswith("exec(")
-                or shortened.startswith("compile(")
-                or shortened.startswith("open(")
-                or shortened.startswith("_run_code(")
-                or shortened.startswith("execWrapper(")
-            ):
+            if any(shortened.startswith(prefix) for prefix in OVERTLY_BAD_CALL_PREFIXES):
                 # this is overtly bad, so record it and print it at the end
                 yield AnalysisResult(
                     Severity.OVERTLY_MALICIOUS,
@@ -607,8 +608,7 @@ class ExpansionAttackAnalysis(Analysis):
         # Multiple indicators together are more severe
         if len(findings) > 1:
             for finding in findings:
-                if finding.severity < Severity.LIKELY_UNSAFE:
-                    finding.severity = Severity.LIKELY_UNSAFE
+                finding.severity = max(finding.severity, Severity.LIKELY_UNSAFE)
 
         yield from findings
 

--- a/fickling/context.py
+++ b/fickling/context.py
@@ -1,7 +1,6 @@
 import pickle
 
-import fickling.hook as hook
-import fickling.loader as loader
+from fickling import hook, loader
 from fickling.analysis import Severity
 
 

--- a/fickling/context.py
+++ b/fickling/context.py
@@ -1,4 +1,4 @@
-import fickling.hook as hook
+from fickling import hook
 
 
 class FicklingContextManager:

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -21,16 +21,15 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Self
-
 from fickling.exception import ExpansionAttackError, ResourceExhaustionError, WrongMethodError
 
 T = TypeVar("T")
 
 if sys.version_info < (3, 12):
-    from typing_extensions import Buffer
+    from typing_extensions import Buffer, Self
 else:
     from collections.abc import Buffer
+    from typing import Self
 
 
 @dataclass(frozen=True)

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -556,7 +556,7 @@ class ConstantOpcode(Opcode):
 
     def __init_subclass__(cls, **kwargs):
         ret = super().__init_subclass__(**kwargs)
-        if not cls.__name__ == "ConstantInt":
+        if cls.__name__ != "ConstantInt":
             if cls.validate.__code__ == ConstantOpcode.validate.__code__:
                 raise TypeError(f"{cls.__name__} must implement the validate method")
             if (
@@ -1330,9 +1330,9 @@ on the Pickled object instead"""
 
     def unsafe_imports(self) -> Iterator[ast.Import | ast.ImportFrom]:
         for node in self.properties.imports:
-            if any(c in UNSAFE_IMPORTS for c in import_name_components(node)):
-                yield node
-            elif "eval" in (n.name for n in node.names):
+            unsafe_module = any(c in UNSAFE_IMPORTS for c in import_name_components(node))
+            imports_eval = "eval" in (n.name for n in node.names)
+            if unsafe_module or imports_eval:
                 yield node
 
     def non_standard_imports(self) -> Iterator[ast.Import | ast.ImportFrom]:

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -1847,7 +1847,7 @@ class AddItems(Opcode):
         else:
             raise InterpretationError("Exhausted the stack while searching for a MarkObject!")
         if not interpreter.stack:
-            raise ValueError("Stack was empty; expected a pyset")
+            raise InterpretationError("Stack was empty; expected a pyset")
         pyset = interpreter.stack[-1]
         if not isinstance(pyset, ast.Set):
             raise InterpretationError(

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -15,6 +15,7 @@ from pickletools import OpcodeInfo, genops, opcodes
 from typing import (
     Any,
     BinaryIO,
+    ClassVar,
     Generic,
     TypeVar,
     overload,
@@ -457,14 +458,8 @@ class Opcode:
         return super().__init_subclass__(**kwargs)
 
     def __repr__(self):
-        if self.pos is None:
-            p = ""
-        else:
-            p = f", position={self.pos!r}"
-        if self.has_data():
-            d = f", data={self.data!r}"
-        else:
-            d = ""
+        p = "" if self.pos is None else f", position={self.pos!r}"
+        d = f", data={self.data!r}" if self.has_data() else ""
         return f"{self.__class__.__name__}(info={self.info!r}, argument={self.arg!r}{d}{p})"
 
 
@@ -477,7 +472,7 @@ class DynamicLength(Opcode, ABC):
     length_signed: bool = False
     length_bytes: int = 4
     length_endianness: Endianness = Endianness.Little
-    struct_types = {1: "b", 2: "h", 4: "i", 8: "q"}
+    struct_types: ClassVar[dict[int, str]] = {1: "b", 2: "h", 4: "i", 8: "q"}
     min_value: int
     max_value: int
 
@@ -548,7 +543,7 @@ def raw_unicode_escape(byte_string: bytes) -> str:
 
 
 class ConstantOpcode(Opcode):
-    ConstantOpcodePriorities: dict[type[ConstantOpcode], int] = {}
+    ConstantOpcodePriorities: ClassVar[dict[type[ConstantOpcode], int]] = {}
     priority: int
 
     def run(self, interpreter: Interpreter):
@@ -602,7 +597,7 @@ class ConstantInt(ConstantOpcode, ABC):
     signed: bool = False
     num_bytes: int = 4
     endianness: Endianness = Endianness.Little
-    struct_types = {1: "b", 2: "h", 4: "i", 8: "q"}
+    struct_types: ClassVar[dict[int, str]] = {1: "b", 2: "h", 4: "i", 8: "q"}
     min_value: int
     max_value: int
 
@@ -1258,10 +1253,7 @@ class Pickled(OpcodeSequence):
                     if pos is not None:
                         pickled.seek(pos)
                     if info.arg is None or info.arg.n == 0:
-                        if pos is not None:
-                            data = None
-                        else:
-                            data = info.code.encode("utf-8")
+                        data = info.code.encode("utf-8") if pos is None else None
                     elif info.arg.n > 0 and pos is not None:
                         data = pickled.read(len(info.code) + info.arg.n)
                         if len(data) != len(info.code) + info.arg.n:
@@ -1279,10 +1271,10 @@ class Pickled(OpcodeSequence):
         except ValueError as e:
             if opcodes:
                 if fail_on_decode_error:
-                    raise PickleDecodeError(e)
+                    raise PickleDecodeError(e) from e
                 has_invalid_opcode = True
             else:
-                raise EmptyPickleError()
+                raise EmptyPickleError() from e
         if opcodes:
             if opcodes[-1].pos is not None:
                 if opcodes[-1].has_data():
@@ -1531,11 +1523,11 @@ class Interpreter:
 
     def run(self):
         self.pickled.validate_frames()
-        while True:
-            try:
+        try:
+            while True:
                 self.step()
-            except StopIteration:
-                break
+        except StopIteration:
+            pass
 
     def step(self) -> Opcode:
         try:

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -1695,7 +1695,7 @@ class AddItems(Opcode):
         else:
             raise InterpretationError("Exhausted the stack while searching for a MarkObject!")
         if not interpreter.stack:
-            raise ValueError("Stack was empty; expected a pyset")
+            raise InterpretationError("Stack was empty; expected a pyset")
         pyset = interpreter.stack[-1]
         if not isinstance(pyset, ast.Set):
             raise InterpretationError(

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -21,6 +21,8 @@ from typing import (
     overload,
 )
 
+from typing_extensions import Self
+
 from fickling.exception import ExpansionAttackError, ResourceExhaustionError, WrongMethodError
 
 T = TypeVar("T")
@@ -577,7 +579,7 @@ class ConstantOpcode(Opcode):
         raise NotImplementedError()
 
     @classmethod
-    def new(cls: type[T], obj) -> T:
+    def new(cls, obj) -> Self:
         for subclass, _ in sorted(
             ConstantOpcode.ConstantOpcodePriorities.items(), key=lambda kv: kv[1]
         ):
@@ -724,8 +726,6 @@ class EmptyPickleError(PickleDecodeError):
 
 class InterpretationError(PickleDecodeError):
     """Raised when pickle interpretation fails due to malformed opcode sequences."""
-
-    pass
 
 
 @dataclass(frozen=True)
@@ -1123,8 +1123,7 @@ class Pickled(OpcodeSequence):
 
     def dump(self, file: BinaryIO, reframe: bool = True):
         """Serialize the opcode sequence to `file`. See `dumps()` for `reframe`."""
-        for chunk in self._output_chunks(reframe):
-            file.write(chunk)
+        file.write(chunk for chunk in self._output_chunks(reframe))
 
     def dumps_partial(self, from_idx: int, to_idx: int) -> bytes:
         """Dump bytecode only between two opcodes
@@ -1851,7 +1850,7 @@ class AddItems(Opcode):
             raise ValueError("Stack was empty; expected a pyset")
         pyset = interpreter.stack[-1]
         if not isinstance(pyset, ast.Set):
-            raise ValueError(
+            raise InterpretationError(
                 f"{pyset!r} was expected to be a set-like object with an `add` function"
             )
         # Check for cyclic references - sets cannot contain themselves (unhashable)
@@ -2295,7 +2294,9 @@ class Append(Opcode):
                 interpreter._has_cycle = True
             list_obj.elts.append(value)
         else:
-            raise ValueError(f"Expected a list on the stack, but instead found {list_obj!r}")
+            raise InterpretationError(
+                f"Expected a list on the stack, but instead found {list_obj!r}"
+            )
 
 
 class Appends(StackSliceOpcode):
@@ -2310,7 +2311,9 @@ class Appends(StackSliceOpcode):
                     interpreter._has_cycle = True
             list_obj.elts.extend(stack_slice)
         else:
-            raise ValueError(f"Expected a list on the stack, but instead found {list_obj!r}")
+            raise InterpretationError(
+                f"Expected a list on the stack, but instead found {list_obj!r}"
+            )
 
 
 class BinFloat(ConstantOpcode):

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -15,6 +15,7 @@ from pickletools import OpcodeInfo, genops, opcodes
 from typing import (
     Any,
     BinaryIO,
+    ClassVar,
     Generic,
     TypeVar,
     overload,
@@ -455,14 +456,8 @@ class Opcode:
         return super().__init_subclass__(**kwargs)
 
     def __repr__(self):
-        if self.pos is None:
-            p = ""
-        else:
-            p = f", position={self.pos!r}"
-        if self.has_data():
-            d = f", data={self.data!r}"
-        else:
-            d = ""
+        p = "" if self.pos is None else f", position={self.pos!r}"
+        d = f", data={self.data!r}" if self.has_data() else ""
         return f"{self.__class__.__name__}(info={self.info!r}, argument={self.arg!r}{d}{p})"
 
 
@@ -475,7 +470,7 @@ class DynamicLength(Opcode, ABC):
     length_signed: bool = False
     length_bytes: int = 4
     length_endianness: Endianness = Endianness.Little
-    struct_types = {1: "b", 2: "h", 4: "i", 8: "q"}
+    struct_types: ClassVar[dict[int, str]] = {1: "b", 2: "h", 4: "i", 8: "q"}
     min_value: int
     max_value: int
 
@@ -546,7 +541,7 @@ def raw_unicode_escape(byte_string: bytes) -> str:
 
 
 class ConstantOpcode(Opcode):
-    ConstantOpcodePriorities: dict[type[ConstantOpcode], int] = {}
+    ConstantOpcodePriorities: ClassVar[dict[type[ConstantOpcode], int]] = {}
     priority: int
 
     def run(self, interpreter: Interpreter):
@@ -600,7 +595,7 @@ class ConstantInt(ConstantOpcode, ABC):
     signed: bool = False
     num_bytes: int = 4
     endianness: Endianness = Endianness.Little
-    struct_types = {1: "b", 2: "h", 4: "i", 8: "q"}
+    struct_types: ClassVar[dict[int, str]] = {1: "b", 2: "h", 4: "i", 8: "q"}
     min_value: int
     max_value: int
 
@@ -1107,10 +1102,7 @@ class Pickled(OpcodeSequence):
                     if pos is not None:
                         pickled.seek(pos)
                     if info.arg is None or info.arg.n == 0:
-                        if pos is not None:
-                            data = None
-                        else:
-                            data = info.code.encode("utf-8")
+                        data = info.code.encode("utf-8") if pos is None else None
                     elif info.arg.n > 0 and pos is not None:
                         data = pickled.read(len(info.code) + info.arg.n)
                         if len(data) != len(info.code) + info.arg.n:
@@ -1128,10 +1120,10 @@ class Pickled(OpcodeSequence):
         except ValueError as e:
             if opcodes:
                 if fail_on_decode_error:
-                    raise PickleDecodeError(e)
+                    raise PickleDecodeError(e) from e
                 has_invalid_opcode = True
             else:
-                raise EmptyPickleError()
+                raise EmptyPickleError() from e
         if opcodes:
             if opcodes[-1].pos is not None:
                 if opcodes[-1].has_data():
@@ -1379,11 +1371,11 @@ class Interpreter:
         self._opcodes = iter(())
 
     def run(self):
-        while True:
-            try:
+        try:
+            while True:
                 self.step()
-            except StopIteration:
-                break
+        except StopIteration:
+            pass
 
     def step(self) -> Opcode:
         try:

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -1122,7 +1122,7 @@ class Pickled(OpcodeSequence):
 
     def dump(self, file: BinaryIO, reframe: bool = True):
         """Serialize the opcode sequence to `file`. See `dumps()` for `reframe`."""
-        file.write(chunk for chunk in self._output_chunks(reframe))
+        file.writelines(self._output_chunks(reframe))
 
     def dumps_partial(self, from_idx: int, to_idx: int) -> bytes:
         """Dump bytecode only between two opcodes

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -21,6 +21,8 @@ from typing import (
     overload,
 )
 
+from typing_extensions import Self
+
 from fickling.exception import ExpansionAttackError, ResourceExhaustionError, WrongMethodError
 
 T = TypeVar("T")
@@ -575,7 +577,7 @@ class ConstantOpcode(Opcode):
         raise NotImplementedError()
 
     @classmethod
-    def new(cls: type[T], obj) -> T:
+    def new(cls, obj) -> Self:
         for subclass, _ in sorted(
             ConstantOpcode.ConstantOpcodePriorities.items(), key=lambda kv: kv[1]
         ):
@@ -722,8 +724,6 @@ class EmptyPickleError(PickleDecodeError):
 
 class InterpretationError(PickleDecodeError):
     """Raised when pickle interpretation fails due to malformed opcode sequences."""
-
-    pass
 
 
 class Pickled(OpcodeSequence):
@@ -1029,8 +1029,7 @@ class Pickled(OpcodeSequence):
         return bytes(b)
 
     def dump(self, file: BinaryIO):
-        for opcode in self:
-            file.write(opcode.data)
+        file.writelines(opcode.data for opcode in self)
 
     def dumps_partial(self, from_idx: int, to_idx: int) -> bytes:
         """Dump bytecode only between two opcodes
@@ -1699,7 +1698,7 @@ class AddItems(Opcode):
             raise ValueError("Stack was empty; expected a pyset")
         pyset = interpreter.stack[-1]
         if not isinstance(pyset, ast.Set):
-            raise ValueError(
+            raise InterpretationError(
                 f"{pyset!r} was expected to be a set-like object with an `add` function"
             )
         # Check for cyclic references - sets cannot contain themselves (unhashable)
@@ -2134,7 +2133,9 @@ class Append(Opcode):
                 interpreter._has_cycle = True
             list_obj.elts.append(value)
         else:
-            raise ValueError(f"Expected a list on the stack, but instead found {list_obj!r}")
+            raise InterpretationError(
+                f"Expected a list on the stack, but instead found {list_obj!r}"
+            )
 
 
 class Appends(StackSliceOpcode):
@@ -2149,7 +2150,9 @@ class Appends(StackSliceOpcode):
                     interpreter._has_cycle = True
             list_obj.elts.extend(stack_slice)
         else:
-            raise ValueError(f"Expected a list on the stack, but instead found {list_obj!r}")
+            raise InterpretationError(
+                f"Expected a list on the stack, but instead found {list_obj!r}"
+            )
 
 
 class BinFloat(ConstantOpcode):

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -554,7 +554,7 @@ class ConstantOpcode(Opcode):
 
     def __init_subclass__(cls, **kwargs):
         ret = super().__init_subclass__(**kwargs)
-        if not cls.__name__ == "ConstantInt":
+        if cls.__name__ != "ConstantInt":
             if cls.validate.__code__ == ConstantOpcode.validate.__code__:
                 raise TypeError(f"{cls.__name__} must implement the validate method")
             if (
@@ -1179,9 +1179,9 @@ on the Pickled object instead"""
 
     def unsafe_imports(self) -> Iterator[ast.Import | ast.ImportFrom]:
         for node in self.properties.imports:
-            if any(c in UNSAFE_IMPORTS for c in import_name_components(node)):
-                yield node
-            elif "eval" in (n.name for n in node.names):
+            unsafe_module = any(c in UNSAFE_IMPORTS for c in import_name_components(node))
+            imports_eval = "eval" in (n.name for n in node.names)
+            if unsafe_module or imports_eval:
                 yield node
 
     def non_standard_imports(self) -> Iterator[ast.Import | ast.ImportFrom]:

--- a/fickling/hook.py
+++ b/fickling/hook.py
@@ -2,7 +2,7 @@ import _pickle
 import io
 import pickle
 
-import fickling.loader as loader
+from fickling import loader
 from fickling.ml import FicklingMLUnpickler
 
 _original_pickle_load = pickle.load

--- a/fickling/hook.py
+++ b/fickling/hook.py
@@ -2,7 +2,7 @@ import _pickle
 import io
 import pickle
 
-import fickling.loader as loader
+from fickling import loader
 from fickling.ml import FicklingMLUnpickler
 
 # pickle._* are the Python implementations, and are still usable even

--- a/fickling/import_hook.py
+++ b/fickling/import_hook.py
@@ -6,7 +6,7 @@ import warnings
 from collections.abc import Sequence
 from types import ModuleType
 
-import fickling.loader as loader
+from fickling import loader
 
 warnings.warn(
     "This feature is experimental and should not be used for safety-critical endeavors.",

--- a/fickling/loader.py
+++ b/fickling/loader.py
@@ -246,7 +246,7 @@ def _scan_bytes(
                 results.append(result)
                 if result.severity > overall_severity:
                     overall_severity = result.severity
-            except Exception as e:
+            except Exception as e:  # noqa: PERF203 -- each pickle is analyzed independently
                 if graceful:
                     errors.append(f"Analysis error ({type(e).__name__}): {e!s}")
                     overall_severity = max(overall_severity, Severity.LIKELY_UNSAFE)

--- a/fickling/loader.py
+++ b/fickling/loader.py
@@ -244,8 +244,7 @@ def _scan_bytes(
             try:
                 result = check_safety(pickled, json_output_path=json_output_path)
                 results.append(result)
-                if result.severity > overall_severity:
-                    overall_severity = result.severity
+                overall_severity = max(overall_severity, result.severity)
             except Exception as e:  # noqa: PERF203 -- each pickle is analyzed independently
                 if graceful:
                     errors.append(f"Analysis error ({type(e).__name__}): {e!s}")

--- a/fickling/polyglot.py
+++ b/fickling/polyglot.py
@@ -44,12 +44,12 @@ Another useful reference is https://github.com/lutzroeder/netron/blob/main/sourc
 
 try:
     from torch.serialization import _is_zipfile
-except ModuleNotFoundError:
+except ModuleNotFoundError as e:
     raise ImportError(
         "The 'torch' module is required for this functionality."
         "PyTorch is now an optional dependency in Fickling."
         "Please use `pip install fickling[torch]`"
-    )
+    ) from e
 
 
 def check_and_find_in_zip(
@@ -367,14 +367,14 @@ def check_for_corruption(properties):
     corrupted = False
     reason = ""
     # We expect this to be expanded upon
-    if properties["is_torch_zip"]:
-        if (
-            properties["has_model_json"]
-            and not properties["has_attributes_pkl"]
-            and not properties["has_constants_pkl"]
-        ):
-            corrupted = True
-            reason = """Your file may be corrupted. It contained a
+    if (
+        properties["is_torch_zip"]
+        and properties["has_model_json"]
+        and not properties["has_attributes_pkl"]
+        and not properties["has_constants_pkl"]
+    ):
+        corrupted = True
+        reason = """Your file may be corrupted. It contained a
             model.json file without an attributes.pkl or constants.pkl file."""
     return corrupted, reason
 
@@ -431,11 +431,8 @@ def identify_pytorch_file_format(
         if print_results:
             print("Your file is most likely of this format: ", primary, "\n")
         secondary = formats[1:]
-        if len(secondary) != 0:
-            if print_results:
-                print(
-                    "It is also possible that your file can be validly interpreted as: ", secondary
-                )
+        if len(secondary) != 0 and print_results:
+            print("It is also possible that your file can be validly interpreted as: ", secondary)
     else:
         if print_results:
             print(
@@ -466,8 +463,7 @@ def create_mar_legacy_pickle_polyglot(
         print("Making a PyTorch MAR/PyTorch v0.1.10 polyglot")
     polyglot_file = append_file(*[file[0] for file in files])
     shutil.copy(polyglot_file, polyglot_file_name)
-    polyglot_found = True
-    return polyglot_found
+    return True
 
 
 def create_standard_torchscript_polyglot(
@@ -476,8 +472,8 @@ def create_standard_torchscript_polyglot(
     if print_results:
         print("Making a PyTorch v1.3/TorchScript v1.4 polyglot")
         print("Warning: For some parsers, this may generate polymocks instead of polyglots.")
-    standard_pytorch_file = [file[0] for file in files if file[1] == "PyTorch v1.3"][0]
-    torchscript_file = [file[0] for file in files if file[1] == "TorchScript v1.4"][0]
+    standard_pytorch_file = next(file[0] for file in files if file[1] == "PyTorch v1.3")
+    torchscript_file = next(file[0] for file in files if file[1] == "TorchScript v1.4")
     if polyglot_file_name is None:
         polyglot_file_name = "polyglot.pt"
     shutil.copy(standard_pytorch_file, polyglot_file_name)
@@ -495,8 +491,7 @@ def create_standard_torchscript_polyglot(
                 zip_out.writestr("constants.pkl", constants_data)
                 zip_out.writestr("version", version_data)
 
-    polyglot_found = True
-    return polyglot_found
+    return True
 
 
 def create_mar_legacy_tar_polyglot(
@@ -504,12 +499,11 @@ def create_mar_legacy_tar_polyglot(
 ):
     if print_results:
         print("Making a PyTorch v0.1.1/PyTorch MAR polyglot")
-    mar_file = [file[0] for file in files if file[1] == "PyTorch model archive format"][0]
-    tar_file = [file[0] for file in files if file[1] == "PyTorch v0.1.1"][0]
+    mar_file = next(file[0] for file in files if file[1] == "PyTorch model archive format")
+    tar_file = next(file[0] for file in files if file[1] == "PyTorch v0.1.1")
     polyglot_file = append_file(mar_file, tar_file)
     shutil.copy(polyglot_file, polyglot_file_name)
-    polyglot_found = True
-    return polyglot_found
+    return True
 
 
 def create_polyglot(first_file, second_file, polyglot_file_name=None, print_results=True):

--- a/fickling/polyglot.py
+++ b/fickling/polyglot.py
@@ -244,7 +244,7 @@ def find_file_properties_recursively(file_path, print_properties=False):
     check_zip = properties["is_standard_zip"]
     # if it's the correct type of zip to be torch, make sure it's not a torch file
     if check_zip and not properties["is_standard_not_torch"]:
-        for key in properties.keys():
+        for key in properties:
             if key.startswith("has_") and properties[key]:
                 # if it is a torch file, no need to check it
                 check_zip = False
@@ -319,7 +319,7 @@ def find_file_properties_recursively(file_path, print_properties=False):
     return properties
 
 
-def check_if_legacy_format(file):
+def check_if_legacy_format(file: str | os.PathLike[str]) -> bool:
     """PyTorch v0.1.1: Tar file with sys_info, pickle, storages, and tensors"""
     required_entries = {"pickle", "storages", "tensors"}
     found_entries = set()
@@ -334,9 +334,10 @@ def check_if_legacy_format(file):
     except Exception:  # noqa
         print("False")
         return False
+    return False
 
 
-def check_if_model_archive_format(file, properties):
+def check_if_model_archive_format(file: str | os.PathLike[str], properties: FileProperties) -> bool:
     """
     PyTorch model archive format: ZIP file that includes Python code files and pickle files
 
@@ -358,6 +359,7 @@ def check_if_model_archive_format(file, properties):
         ) or check_and_find_in_7z(file, ".pth", check_extension=True)
         has_code = check_and_find_in_7z(file, ".py", check_extension=True)
         return has_json and has_serialized_model and has_code
+    return False
 
 
 def check_for_corruption(properties):
@@ -512,8 +514,8 @@ def create_mar_legacy_tar_polyglot(
 
 def create_polyglot(first_file, second_file, polyglot_file_name=None, print_results=True):
     polyglot_found = False
-    temp_first_file = "temp_" + os.path.basename(first_file)
-    temp_second_file = "temp_" + os.path.basename(second_file)
+    temp_first_file = "temp_" + Path(first_file).name
+    temp_second_file = "temp_" + Path(second_file).name
     shutil.copy(first_file, temp_first_file)
     shutil.copy(second_file, temp_second_file)
     files: list[tuple[str, str]] = []
@@ -549,6 +551,6 @@ def create_polyglot(first_file, second_file, polyglot_file_name=None, print_resu
             )
         else:
             print(f"The polyglot is contained in {polyglot_file_name}")
-    os.remove(temp_first_file)
-    os.remove(temp_second_file)
+    Path(temp_first_file).unlink()
+    Path(temp_second_file).unlink()
     return polyglot_found

--- a/fickling/pytorch.py
+++ b/fickling/pytorch.py
@@ -9,12 +9,12 @@ from fickling.fickle import Pickled
 
 try:
     import torch
-except ModuleNotFoundError:
+except ModuleNotFoundError as e:
     raise ImportError(
         "The 'torch' module is required for this functionality."
         "PyTorch is now an optional dependency in Fickling."
         "Please use `pip install fickling[torch]`"
-    )
+    ) from e
 
 
 class BaseInjection(torch.nn.Module):
@@ -55,6 +55,7 @@ class PyTorchModelWrapper:
                     If it is a PyTorch file, raise an issue on GitHub
                     """,
                     UserWarning,
+                    stacklevel=2,
                 )
             else:
                 raise ValueError(
@@ -72,6 +73,7 @@ class PyTorchModelWrapper:
                         Try Pickled.load() or StackedPickle.load() if this fails
                         """,
                         UserWarning,
+                        stacklevel=2,
                     )
                 else:
                     raise ValueError(
@@ -87,6 +89,7 @@ class PyTorchModelWrapper:
                         """A fickling wrapper and injection method does not exist for that format.
                         Please raise an issue on our GitHub.""",
                         UserWarning,
+                        stacklevel=2,
                     )
                 else:
                     raise NotImplementedError(
@@ -97,6 +100,7 @@ class PyTorchModelWrapper:
             warnings.warn(
                 """Support for TorchScript v1.4 files is experimental.""",
                 UserWarning,
+                stacklevel=2,
             )
         return self._formats
 
@@ -129,6 +133,7 @@ class PyTorchModelWrapper:
                 """Support for TorchScript  v1.4 files is experimental.
                 Injections may not be effective depending on the model and the target parser.""",
                 UserWarning,
+                stacklevel=2,
             )
         if injection == "insertion":
             # This does NOT bypass the weights based unpickler
@@ -137,14 +142,16 @@ class PyTorchModelWrapper:
             pickled.insert_python_exec(payload)
 
             # Create a new ZIP file to store the modified data
-            with zipfile.ZipFile(output_path, "w") as new_zip_ref:
-                with zipfile.ZipFile(self.path, "r") as zip_ref:
-                    for item in zip_ref.infolist():
-                        with zip_ref.open(item.filename) as entry:
-                            if item.filename.endswith("/data.pkl"):
-                                new_zip_ref.writestr(item.filename, pickled.dumps())
-                            else:
-                                new_zip_ref.writestr(item.filename, entry.read())
+            with (
+                zipfile.ZipFile(output_path, "w") as new_zip_ref,
+                zipfile.ZipFile(self.path, "r") as zip_ref,
+            ):
+                for item in zip_ref.infolist():
+                    with zip_ref.open(item.filename) as entry:
+                        if item.filename.endswith("/data.pkl"):
+                            new_zip_ref.writestr(item.filename, pickled.dumps())
+                        else:
+                            new_zip_ref.writestr(item.filename, entry.read())
         if injection == "combination":
             injected_model = BaseInjection(self.pickled, payload)
             torch.save(injected_model, output_path)

--- a/fickling/pytorch.py
+++ b/fickling/pytorch.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import warnings
 import zipfile
 from pathlib import Path
@@ -154,4 +153,4 @@ class PyTorchModelWrapper:
             Path(output_path).rename(self.path)
             output_path = Path(self.output_path)
             if output_path.exists():
-                os.remove(output_path)
+                output_path.unlink()

--- a/fickling/tracing.py
+++ b/fickling/tracing.py
@@ -9,17 +9,11 @@ class Trace:
         self.interpreter: Interpreter = interpreter
 
     def on_pop(self, popped_value: ast.expr | MarkObject):
-        if isinstance(popped_value, MarkObject):
-            value = "MARK"
-        else:
-            value = unparse(popped_value).strip()
+        value = "MARK" if isinstance(popped_value, MarkObject) else unparse(popped_value).strip()
         print(f"\tPopped {value}")
 
     def on_push(self, pushed_value: ast.expr | MarkObject):
-        if isinstance(pushed_value, MarkObject):
-            value = "MARK"
-        else:
-            value = unparse(pushed_value).strip()
+        value = "MARK" if isinstance(pushed_value, MarkObject) else unparse(pushed_value).strip()
         print(f"\tPushed {value}")
 
     def on_memoize(self, index: int, value: ast.expr):

--- a/pickle_scanning_benchmark/benchmark.py
+++ b/pickle_scanning_benchmark/benchmark.py
@@ -138,8 +138,8 @@ def _analyze_file(
             else:
                 results.tools[toolname].add_fp()
                 logger.warning(f"Clean file mislabeled by {toolname}: {fileinfo['file']}")
-        except KeyboardInterrupt as e:
-            raise e
+        except KeyboardInterrupt:
+            raise
         except Exception as e:
             print(traceback.format_exc())
             logger.error(f"Failed to analyze file: {e}")
@@ -154,8 +154,8 @@ def _analyze_file(
                 )
             else:
                 results.tools[toolname].add_tp()
-        except KeyboardInterrupt as e:
-            raise e
+        except KeyboardInterrupt:
+            raise
         except Exception as e:
             print(traceback.format_exc())
             logger.error(f"Failed to analyze file: {e}")

--- a/pickle_scanning_benchmark/benchmark.py
+++ b/pickle_scanning_benchmark/benchmark.py
@@ -64,7 +64,7 @@ def load_index(filepath):
         return json.load(f)
 
 
-def run_fickling(filepath, filetype):
+def run_fickling(filepath, filetype) -> bool:
     analysis = [
         MLAllowlist(),  # Import non standard non whitelisted stuff
         UnsafeImportsML(),  # Importing from unsafe modules
@@ -74,6 +74,7 @@ def run_fickling(filepath, filetype):
         return run_fickling_pickle(filepath, analysis)
     if filetype == "pytorch":
         return run_fickling_pytorch(filepath, analysis)
+    raise Exception("Unsupported file type")
 
 
 def run_fickling_pickle(filepath, analysis) -> bool:

--- a/pickle_scanning_benchmark/benchmark.py
+++ b/pickle_scanning_benchmark/benchmark.py
@@ -8,9 +8,9 @@ import random
 import sys
 import traceback
 import zipfile
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, Optional
 
 import logger
 import picklescan.scanner as ps_scanner
@@ -29,7 +29,7 @@ class ModelUnpickler(SafeUnpickler):
         return None
 
 
-setattr(pickle, "Unpickler", SafeUnpickler)
+pickle.Unpickler = SafeUnpickler
 
 # Logging
 ps_scanner._log.propagate = False
@@ -38,7 +38,7 @@ DEVNULL = open(os.devnull, "w")
 
 # TODO(boyan): do this when downloading the files
 def is_valid(filepath, filetype):
-    if not os.path.isfile(filepath):
+    if not Path(filepath).is_file():
         return False
     with open(filepath, "rb") as f:
         if f.read(100).startswith(b"Access to model"):
@@ -72,7 +72,7 @@ def run_fickling(filepath, filetype):
     ]
     if filetype == "pickle":
         return run_fickling_pickle(filepath, analysis)
-    elif filetype == "pytorch":
+    if filetype == "pytorch":
         return run_fickling_pytorch(filepath, analysis)
 
 
@@ -95,9 +95,7 @@ def run_fickling_pytorch(filepath, analysis) -> bool:
 def run_modelscan(filepath, filetype):
     ms = ModelScan()
     res = ms.scan(filepath)
-    if res["issues"]:
-        return False
-    return True
+    return not res["issues"]
 
 
 def run_modelunpickler(filepath, filetype):
@@ -118,19 +116,16 @@ def run_picklescan(filepath, filetype):
     results = ps_scanner.scan_file_path(filepath)
     if results.scan_err:
         raise Exception("Failed to analyze file with picklescan. res.scan_err = True")
-    if results.issues_count == 0:
-        return True  # Safe
-    else:
-        return False  # Unsafe
+    return results.issues_count == 0  # True if safe
 
 
 def _analyze_file(
     toolname: str,
     run_tool_func: Callable,
-    fileinfo: Dict,
-    results: Dict[str, "BenchmarkResults"],
+    fileinfo: dict,
+    results: dict[str, "BenchmarkResults"],
     expected_scan_result: bool,  # True for clean files, False for malicious files
-    payload: Optional[str] = None,
+    payload: str | None = None,
 ):
     logger.info(f"Running {toolname} on {fileinfo['file']}")
     # Run tool
@@ -227,7 +222,7 @@ class ToolResults:
     nb_scanned_files: int = 0  # Files scanned without errors
     nb_failed_files: int = 0  # The tool failed to scan the files
 
-    fn_payload_types: Dict[str, int] = field(default_factory=dict)  # <payload type> --> how many
+    fn_payload_types: dict[str, int] = field(default_factory=dict)  # <payload type> --> how many
 
     @property
     def total_files(self) -> int:
@@ -241,7 +236,7 @@ class ToolResults:
         self.fp_clean += n
         self.nb_scanned_files += n
 
-    def add_fn(self, n=1, payload: Optional[str] = None):
+    def add_fn(self, n=1, payload: str | None = None):
         self.fn_malicious += n
         self.nb_scanned_files += n
         if payload:
@@ -284,7 +279,7 @@ class BenchmarkResults:
     nb_malicious_files: int = 0  # Total seen malicious files
     nb_invalid_files: int = 0  # Files where even pickletools fail
 
-    tools: Dict[str, ToolResults] = field(default_factory=dict)
+    tools: dict[str, ToolResults] = field(default_factory=dict)
 
     @staticmethod
     def new(*tools):

--- a/pickle_scanning_benchmark/download.py
+++ b/pickle_scanning_benchmark/download.py
@@ -1,11 +1,9 @@
 import argparse
 import json
-import os
 import shutil
 import zipfile
 from pathlib import Path
 from pprint import pprint
-from typing import Optional
 
 import logger
 import requests
@@ -13,7 +11,7 @@ import requests
 
 def hf_download_pickle_files(
     infile: Path,
-    outdir: Optional[Path] = None,
+    outdir: Path | None = None,
     n: int = 10,  # number of files to download
     mode: str = "default",  # default, overwrite, add
     maxsize: int = 500000000,  # in bytes
@@ -24,7 +22,7 @@ def hf_download_pickle_files(
     if mode not in ["default", "overwrite", "add"]:
         raise ValueError(f"Invalid mode: '{mode}'")
     if outdir is None:
-        outdir = Path(os.getcwd()) / "pickle_dataset"
+        outdir = Path.cwd() / "pickle_dataset"
     index = []
     if outdir.exists():
         if mode == "overwrite":

--- a/pickle_scanning_benchmark/inject.py
+++ b/pickle_scanning_benchmark/inject.py
@@ -1,5 +1,4 @@
 import json
-import os
 import random
 import sys
 import traceback
@@ -184,7 +183,7 @@ def create_malicious_dataset(clean_dataset_dir: Path, outdir: Path, n: int = 10)
         clean_index = json.load(f)
     malicious_index = []
     for f in clean_index:
-        filename = os.path.basename(f["file"])
+        filename = Path(f["file"]).name
         outfile = outdir / filename
         try:
             # TODO(boyan): check "type" field with new datasets

--- a/pickle_scanning_benchmark/inject.py
+++ b/pickle_scanning_benchmark/inject.py
@@ -6,7 +6,7 @@ import traceback
 import zipfile
 from functools import partial
 from pathlib import Path
-from typing import BinaryIO, Optional
+from typing import BinaryIO
 
 import logger
 
@@ -113,14 +113,13 @@ for key, pl in (EXEC_PRIMITIVE_PAYLOADS | DANGEROUS_PRIMITIVE_PAYLOADS).items():
     _add_simple_payload(key, pl)
 
 
-def _get_payload(payload_key: Optional[str] = None):
+def _get_payload(payload_key: str | None = None):
     if payload_key is None:
         return random.choice(list(ALL_PAYLOADS.items()))
-    else:
-        return (payload_key, ALL_PAYLOADS[payload_key])
+    return (payload_key, ALL_PAYLOADS[payload_key])
 
 
-def _inject_payload(infile: BinaryIO, outfile: BinaryIO, payload_key: Optional[str] = None):
+def _inject_payload(infile: BinaryIO, outfile: BinaryIO, payload_key: str | None = None):
     # Get payload
     payload_id, inject_func = _get_payload(payload_key)
     # Inject
@@ -131,7 +130,7 @@ def _inject_payload(infile: BinaryIO, outfile: BinaryIO, payload_key: Optional[s
     return payload_id
 
 
-def inject_pickle_file(infile: Path, outfile: Path, payload_key: Optional[str] = None):
+def inject_pickle_file(infile: Path, outfile: Path, payload_key: str | None = None):
     """Return the ID of the payload that was injected"""
     print(f"> Injecting payload in {infile}")
     print(f"\t> Writing malicious pickle in {outfile}")
@@ -139,7 +138,7 @@ def inject_pickle_file(infile: Path, outfile: Path, payload_key: Optional[str] =
         return _inject_payload(f, outf, payload_key)
 
 
-def inject_pytorch_file(infile: Path, outfile: Path, payload_key: Optional[str] = None):
+def inject_pytorch_file(infile: Path, outfile: Path, payload_key: str | None = None):
     """Return the ID of the payload that was injected"""
     print(f"> Injecting payload in {infile}")
     print(f"\t> Writing malicious pickle in {outfile}")
@@ -172,8 +171,7 @@ def inject_pytorch_file(infile: Path, outfile: Path, payload_key: Optional[str] 
     # Make sure we injected the payload in a file
     if injected:
         return res
-    else:
-        raise Exception("No pickle found in torch archive")
+    raise Exception("No pickle found in torch archive")
 
 
 def create_malicious_dataset(clean_dataset_dir: Path, outdir: Path, n: int = 10):

--- a/pickle_scanning_benchmark/listfiles.py
+++ b/pickle_scanning_benchmark/listfiles.py
@@ -39,7 +39,7 @@ def hf_get_candidate_files_list(n: int = 100, outfile: Path | None = None):
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} <outfile> <nbfiles>")
-        exit(0)
+        sys.exit(0)
     outfile = sys.argv[1]
     n = int(sys.argv[2])
     hf_get_candidate_files_list(n=n, outfile=outfile)

--- a/pickle_scanning_benchmark/listfiles.py
+++ b/pickle_scanning_benchmark/listfiles.py
@@ -2,12 +2,11 @@ import json
 import sys
 from pathlib import Path
 from pprint import pprint
-from typing import Optional
 
 from huggingface_hub import HfApi
 
 
-def hf_get_candidate_files_list(n: int = 100, outfile: Optional[Path] = None):
+def hf_get_candidate_files_list(n: int = 100, outfile: Path | None = None):
     """Get a list of pickle files currently hosted on HuggingFace.
     :n: the number of files to get"""
     api = HfApi()
@@ -20,10 +19,12 @@ def hf_get_candidate_files_list(n: int = 100, outfile: Optional[Path] = None):
     files = []
     for model in models:
         if model.siblings:
-            for s in model.siblings:
-                if s.rfilename.endswith((".pkl", ".pt", ".pth", ".bin", "pickle", ".pk")):
-                    # TODO(boyan): more filtering here?
-                    files.append({"filename": s.rfilename, "project": model.id})
+            # TODO(boyan): more filtering here?
+            files.extend(
+                {"filename": s.rfilename, "project": model.id}
+                for s in model.siblings
+                if s.rfilename.endswith((".pkl", ".pt", ".pth", ".bin", "pickle", ".pk"))
+            )
         if len(files) >= n:
             break
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ torch = [
     "numpy >= 2.3.5; python_version >= '3.11'",
 ]
 lint = [
-  "ruff >= 0.8.0",
-  "ty >= 0.0.12",
+  "ruff >= 0.16.0",
+  "ty >= 0.0.60",
   # for the Buffer ABC before Python 3.12
   "typing-extensions; python_version < '3.12'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,14 +121,12 @@ select = [
 ignore = [
   "E501",  # line too long (handled by formatter)
   "T201",  # print statements (needed for CLI)
-  "T203",  # pprint statements
   # Pre-existing issues to fix in future PRs
   "PTH123",  # open() should be replaced by Path.open()
   "PTH107",  # os.remove should be replaced by Path.unlink
   "PTH118",  # os.path.join should be replaced by Path
   "PTH119",  # os.path.basename should be replaced by Path.name
   "RUF012",  # Mutable class attributes should use ClassVar
-  "RUF013",  # PEP 484 prohibits implicit Optional
   "B028",   # No explicit stacklevel in warnings
   "B904",   # Use raise ... from within except blocks
   "SIM102",  # Use single if instead of nested if
@@ -146,11 +144,10 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore various checks for benchmark and example code
-"pickle_scanning_benchmark/*.py" = ["BLE", "T20", "N806"]
+"pickle_scanning_benchmark/*.py" = ["BLE", "T20"]
 "example/*.py" = ["T20"]
 "test/*.py" = ["T20"]
 "fickling/hook.py" = ["N816"]
-"fickling/fickle.py" = ["N802"]  # AST visitor methods must be named visit_*
 
 [tool.ruff.lint.isort]
 known-first-party = ["fickling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,15 +100,14 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = [
+# Only prefixes whose rules the defaults do not already cover in full are listed.
+extend-select = [
   "E",     # pycodestyle errors
   "F",     # pyflakes
   "W",     # pycodestyle warnings
   "I",     # isort
   "N",     # pep8-naming
   "UP",    # pyupgrade
-  "YTT",   # flake8-2020
-  "BLE",   # flake8-blind-except
   "B",     # flake8-bugbear
   "C4",    # flake8-comprehensions
   "T20",   # flake8-print
@@ -130,10 +129,11 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-# Ignore various checks for benchmark and example code
-"pickle_scanning_benchmark/*.py" = ["BLE", "T20"]
+"fickling/fickle.py" = ["TRY004"]
+"pickle_scanning_benchmark/*.py" = ["BLE", "LOG015", "T20", "TRY002"]
 "example/*.py" = ["T20"]
 "test/*.py" = ["T20"]
+"test/test_pickle.py" = ["S102"]
 "fickling/hook.py" = ["N816"]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,21 +123,14 @@ ignore = [
   "T201",  # print statements (needed for CLI)
   # Pre-existing issues to fix in future PRs
   "PTH123",  # open() should be replaced by Path.open()
-  "PTH107",  # os.remove should be replaced by Path.unlink
-  "PTH118",  # os.path.join should be replaced by Path
-  "PTH119",  # os.path.basename should be replaced by Path.name
   "RUF012",  # Mutable class attributes should use ClassVar
   "B028",   # No explicit stacklevel in warnings
   "B904",   # Use raise ... from within except blocks
   "SIM102",  # Use single if instead of nested if
   "SIM108",  # Use ternary operator instead of if-else
-  "SIM114",  # Combine if branches with same body
   "SIM115",  # Use context handler for opening files
   "SIM117",  # Use single with statement for multiple contexts
-  "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
-  "SIM201",  # Use `!=` instead of `not ==`
   "PERF203", # try-except in loop could be moved outside
-  "RET503",  # Missing explicit return
   "RET504",  # Unnecessary assignment before return
   "RUF015",  # Prefer next() over list indexing
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ classifiers = [
   "Topic :: Utilities",
 ]
 requires-python = ">=3.10"
+dependencies = [
+  "typing-extensions >= 4.6.0; python_version < '3.12'",
+]
 
 [project.optional-dependencies]
 torch = [
@@ -37,8 +40,6 @@ torch = [
 lint = [
   "ruff >= 0.16.0",
   "ty >= 0.0.60",
-  # for the Buffer ABC before Python 3.12
-  "typing-extensions; python_version < '3.12'",
 ]
 test = [
   "pytest >= 8.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,18 +121,12 @@ select = [
 ignore = [
   "E501",  # line too long (handled by formatter)
   "T201",  # print statements (needed for CLI)
-  # Pre-existing issues to fix in future PRs
-  "PTH123",  # open() should be replaced by Path.open()
-  "RUF012",  # Mutable class attributes should use ClassVar
-  "B028",   # No explicit stacklevel in warnings
-  "B904",   # Use raise ... from within except blocks
-  "SIM102",  # Use single if instead of nested if
-  "SIM108",  # Use ternary operator instead of if-else
-  "SIM115",  # Use context handler for opening files
-  "SIM117",  # Use single with statement for multiple contexts
-  "PERF203", # try-except in loop could be moved outside
-  "RET504",  # Unnecessary assignment before return
-  "RUF015",  # Prefer next() over list indexing
+  # builtin open() is fine; Path.open() is a style preference with no behavioral gain
+  "PTH123",
+  # several call sites intentionally manage the handle themselves: the temporary files in
+  # polyglot.py must be closed before their path is reopened by the recursive scan, and cli.py
+  # binds either a stdio stream or an opened file to the same variable
+  "SIM115",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/test/fixtures/generate_fixtures.py
+++ b/test/fixtures/generate_fixtures.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10,<3.14"
 # dependencies = ["torch>=2.10,<3", "torchvision>=0.25,<1"]
@@ -17,7 +17,7 @@ Usage:
 from pathlib import Path
 
 import torch
-import torchvision.models as models
+from torchvision import models
 
 FIXTURES_DIR = Path(__file__).parent
 

--- a/test/test_crashes.py
+++ b/test/test_crashes.py
@@ -72,7 +72,6 @@ AABfbW9kdWxlc3E2aAopUnE3WAUAAABfa2V5c3E4fXE5aANOc3VidS4="""
     )
     def test_stable_diffusion(self):
         """Reproduces https://github.com/trailofbits/fickling/issues/22"""
-        pass
 
     @unparse_test(
         io.BytesIO(
@@ -82,12 +81,10 @@ AABfbW9kdWxlc3E2aAopUnE3WAUAAABfa2V5c3E4fXE5aANOc3VidS4="""
     def test_pop_mark(self):
         """Tests the correctness of the POP_MARK opcode by using the bytecode from https://github.com/mindspore-ai/mindspore/issues/183
         This can be simplified to allow for the correctness of additional opcodes to be tested"""
-        pass
 
     @unparse_test(io.BytesIO(b'(cos\nsystem\nS"whoami"\no.'))
     def test_obj(self):
         """Tests the correctness of the OBJ opcode"""
-        pass
 
     # Based on the CTF challenge shared in https://github.com/trailofbits/fickling/issues/125.
     def test_stack_global_dynamic_import(self):

--- a/test/test_crashes.py
+++ b/test/test_crashes.py
@@ -306,8 +306,7 @@ class TestInterpreterLimits(TestCase):
         """Test that the max_memo_size limit is enforced."""
         opcodes = [Proto.create(4), EmptyList()]
         # Each Memoize adds a new memo entry
-        for _ in range(20):
-            opcodes.append(Memoize())
+        opcodes.extend(Memoize() for _ in range(20))
         opcodes.append(Stop())
 
         pickled = Pickled(opcodes)

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -65,6 +65,8 @@ class TestHook(unittest.TestCase):
             "_pickle.Unpickler": lambda: _pickle.Unpickler(io.BytesIO(data)).load(),
         }
         for name, call in cases.items():
-            with self.subTest(entry_point=name):
-                with self.assertRaises(UnsafeFileError, msg=f"{name} was not intercepted"):
-                    call()
+            with (
+                self.subTest(entry_point=name),
+                self.assertRaises(UnsafeFileError, msg=f"{name} was not intercepted"),
+            ):
+                call()

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -61,6 +61,8 @@ class TestHook(unittest.TestCase):
             "_pickle.Unpickler": lambda: _pickle.Unpickler(io.BytesIO(data)).load(),
         }
         for name, call in cases.items():
-            with self.subTest(entry_point=name):
-                with self.assertRaises(UnsafeFileError, msg=f"{name} was not intercepted"):
-                    call()
+            with (
+                self.subTest(entry_point=name),
+                self.assertRaises(UnsafeFileError, msg=f"{name} was not intercepted"),
+            ):
+                call()

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -6,7 +6,7 @@ from pickle import UnpicklingError
 
 import numpy
 
-import fickling.hook as hook
+from fickling import hook
 from fickling.exception import UnsafeFileError
 
 

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -484,7 +484,7 @@ class TestInterpreter(TestCase):
             )
             pickled = Pickled.load(io.BytesIO(pickle_bytes))
             result = get_result(pickled)
-            self.assertEqual(result, os.path.join("/home", "user"))
+            self.assertEqual(result, os.path.join("/home", "user"))  # noqa: PTH118
 
             # Compare with real pickle
             real_result = loads(pickle_bytes)

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -431,7 +431,7 @@ class TestInterpreter(TestCase):
             )
             pickled = Pickled.load(io.BytesIO(pickle_bytes))
             result = get_result(pickled)
-            self.assertEqual(result, os.path.join("/home", "user"))
+            self.assertEqual(result, os.path.join("/home", "user"))  # noqa: PTH118
 
             # Compare with real pickle
             real_result = loads(pickle_bytes)

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -42,7 +42,9 @@ def stacked_correctness_test(*to_pickle):
             stacked = [dumps(p) for p in to_pickle_list]
             stacked_pickle = StackedPickle.load(b"".join(stacked))
             self.assertEqual(len(stacked_pickle), len(stacked))
-            for pickled, p_bytes, original in zip(stacked_pickle, stacked, to_pickle_list):
+            for pickled, p_bytes, original in zip(
+                stacked_pickle, stacked, to_pickle_list, strict=True
+            ):
                 stacked_ast = pickled.ast
                 true_ast = Pickled.load(p_bytes).ast
                 stacked_code = unparse(stacked_ast)

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -41,7 +41,9 @@ def stacked_correctness_test(*to_pickle):
             stacked = [dumps(p) for p in to_pickle_list]
             stacked_pickle = StackedPickle.load(b"".join(stacked))
             self.assertEqual(len(stacked_pickle), len(stacked))
-            for pickled, p_bytes, original in zip(stacked_pickle, stacked, to_pickle_list):
+            for pickled, p_bytes, original in zip(
+                stacked_pickle, stacked, to_pickle_list, strict=True
+            ):
                 stacked_ast = pickled.ast
                 true_ast = Pickled.load(p_bytes).ast
                 stacked_code = unparse(stacked_ast)

--- a/test/test_polyglot.py
+++ b/test/test_polyglot.py
@@ -9,9 +9,9 @@ from pathlib import Path
 import numpy as np
 import py7zr
 import torch
-import torchvision.models as models
+from torchvision import models
 
-import fickling.polyglot as polyglot
+from fickling import polyglot
 from fickling.polyglot import FileProperties
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"

--- a/test/test_pytorch.py
+++ b/test/test_pytorch.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from unittest import mock
 
 import torch
-import torchvision.models as models
+from torchvision import models
 
 import fickling.polyglot
 from fickling.fickle import Pickled

--- a/test/test_scan_api.py
+++ b/test/test_scan_api.py
@@ -267,9 +267,11 @@ class TestRelaxedZipFile(unittest.TestCase):
             Path(zip_path).write_bytes(raw)
 
             # Standard ZipFile should raise on read
-            with zipfile.ZipFile(zip_path, "r") as zf:
-                with self.assertRaises(zipfile.BadZipFile):
-                    zf.read("data.pkl")
+            with (
+                zipfile.ZipFile(zip_path, "r") as zf,
+                self.assertRaises(zipfile.BadZipFile),
+            ):
+                zf.read("data.pkl")
 
             # RelaxedZipFile should succeed
             with RelaxedZipFile(zip_path, "r") as rzf:

--- a/test/test_unpickler.py
+++ b/test/test_unpickler.py
@@ -5,7 +5,7 @@ import unittest
 import numpy
 import torch
 
-import fickling.hook as hook
+from fickling import hook
 from fickling.exception import UnsafeFileError
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -522,6 +522,9 @@ wheels = [
 [[package]]
 name = "fickling"
 source = { editable = "." }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
 
 [package.optional-dependencies]
 archive = [
@@ -539,7 +542,6 @@ dev = [
     { name = "torch" },
     { name = "torchvision" },
     { name = "ty" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 examples = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -556,7 +558,6 @@ huggingface = [
 lint = [
     { name = "ruff" },
     { name = "ty" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 test = [
     { name = "coverage", extra = ["toml"] },
@@ -610,8 +611,7 @@ requires-dist = [
     { name = "torchvision", marker = "extra == 'torch'", specifier = ">=0.24.1" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.60" },
     { name = "ty", marker = "extra == 'lint'", specifier = ">=0.0.60" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12' and extra == 'dev'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12' and extra == 'lint'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.6.0" },
 ]
 provides-extras = ["archive", "dev", "examples", "huggingface", "lint", "test", "torch"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "python_full_version < '3.15'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/fe/7351d7e586a8b4c9f89731bfe4cf0148223e8f9903ff09571f78b3fb0682/cuda_bindings-13.2.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08b395f79cb89ce0cd8effff07c4a1e20101b873c256a1aeb286e8fd7bd0f556", size = 5744254, upload-time = "2026-03-11T00:12:29.798Z" },
@@ -468,43 +468,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -512,7 +512,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -598,8 +598,8 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5.0.0" },
     { name = "pytorchfi", marker = "extra == 'examples'" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
-    { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.8.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.0" },
+    { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.16.0" },
     { name = "torch", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "torch", marker = "extra == 'huggingface'", specifier = ">=2.1.0" },
     { name = "torch", marker = "extra == 'test'", specifier = ">=2.1.0" },
@@ -608,8 +608,8 @@ requires-dist = [
     { name = "torchvision", marker = "extra == 'huggingface'", specifier = ">=0.24.1" },
     { name = "torchvision", marker = "extra == 'test'", specifier = ">=0.24.1" },
     { name = "torchvision", marker = "extra == 'torch'", specifier = ">=0.24.1" },
-    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.12" },
-    { name = "ty", marker = "extra == 'lint'", specifier = ">=0.0.12" },
+    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.60" },
+    { name = "ty", marker = "extra == 'lint'", specifier = ">=0.0.60" },
     { name = "typing-extensions", marker = "python_full_version < '3.12' and extra == 'dev'" },
     { name = "typing-extensions", marker = "python_full_version < '3.12' and extra == 'lint'" },
 ]
@@ -1680,27 +1680,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.22"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
-    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "python_full_version < '3.15'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/fe/7351d7e586a8b4c9f89731bfe4cf0148223e8f9903ff09571f78b3fb0682/cuda_bindings-13.2.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08b395f79cb89ce0cd8effff07c4a1e20101b873c256a1aeb286e8fd7bd0f556", size = 5744254, upload-time = "2026-03-11T00:12:29.798Z" },
@@ -468,43 +468,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -512,7 +512,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -598,8 +598,8 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5.0.0" },
     { name = "pytorchfi", marker = "extra == 'examples'" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
-    { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.8.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.0" },
+    { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.16.0" },
     { name = "torch", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "torch", marker = "extra == 'huggingface'", specifier = ">=2.1.0" },
     { name = "torch", marker = "extra == 'test'", specifier = ">=2.1.0" },
@@ -608,8 +608,8 @@ requires-dist = [
     { name = "torchvision", marker = "extra == 'huggingface'", specifier = ">=0.24.1" },
     { name = "torchvision", marker = "extra == 'test'", specifier = ">=0.24.1" },
     { name = "torchvision", marker = "extra == 'torch'", specifier = ">=0.24.1" },
-    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.12" },
-    { name = "ty", marker = "extra == 'lint'", specifier = ">=0.0.12" },
+    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.60" },
+    { name = "ty", marker = "extra == 'lint'", specifier = ">=0.0.60" },
     { name = "typing-extensions", marker = "python_full_version < '3.12' and extra == 'dev'" },
     { name = "typing-extensions", marker = "python_full_version < '3.12' and extra == 'lint'" },
 ]
@@ -1680,27 +1680,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.21"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
-    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
-    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
-    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Bump ruff to v0.16.0, which brings many new rules in the default ruleset.
- Switch `select` to `extend-select` and resolve "fix in future PRs" ignores with autofixes and otherwise manual; only PTH123 and SIM115 remain, with comments. Reformat the Markdown Python snippets that 0.16.0 now formats. 
- Replaced `mypy` with `ty` in the Makefile, which is not installed anymore, and check formatting over `.` like `lint.yml`.
- Declare `typing-extensions` as a runtime dependency on Python < 3.12 since we need `Self`. Bare `pip install fickling` has been unimportable on 3.10/3.11 since v0.1.4 because of that.
- Raise InterpretationError instead of a bare ValueError on malformed `ADDITEMS`, `APPEND` and `APPENDS` opcodes (TRY004).