### PR TITLE
Add a vibe-drafted fuzzing harness for the scanner

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,10 @@
+# Fuzzing is run manually; nothing it produces belongs in the repo.
+.venv/
+artifacts/
+corpus/
+crash-*
+timeout-*
+oom-*
+leak-*
+htmlcov/
+.coverage

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,0 +1,66 @@
+# Fuzzing targets. Run these from this directory: `cd fuzz && make <target>`.
+#
+# Everything goes through `uv run`, which resolves the pinned interpreter and creates .venv
+# from uv.lock on first use, so `make fuzz` works on a fresh checkout with no setup step.
+
+ARGS ?= -max_total_time=60
+
+# --project . rather than discovery, so the targets survive `make -C fuzz` too.
+UV_RUN := uv run --project .
+
+.PHONY: help
+help:
+	@echo "make env        build .venv from uv.lock (needs clang, cargo, dev headers)"
+	@echo "make fuzz       fuzz for 60s; ARGS='-max_total_time=3600 -jobs=4' to extend"
+	@echo "make check      self-test, no fuzzing"
+	@echo "make report     list recorded findings"
+	@echo "make test       unit tests for the harness itself"
+	@echo "make coverage   HTML report of what the corpus reaches in fickling"
+	@echo "make lint       ruff over the harness"
+	@echo "make clean      drop corpus, findings and coverage output"
+
+.PHONY: env
+env:
+# Optional: the first `uv run` would do this anyway. Both deps compile from source, so it
+# needs clang, cargo and the dev headers; uv fetches the interpreter itself.
+	CC=clang CXX=clang++ uv sync --project .
+	@echo "fuzz: ready on $$($(UV_RUN) python -V)"
+
+corpus:
+	$(UV_RUN) python harness.py --write-corpus corpus
+
+.PHONY: fuzz
+fuzz: corpus
+	$(UV_RUN) python harness.py corpus $(ARGS)
+
+.PHONY: check
+check:
+	$(UV_RUN) python harness.py --check
+
+.PHONY: report
+report:
+	$(UV_RUN) python harness.py --summary
+
+.PHONY: test
+test:
+	$(UV_RUN) pytest -q tests/
+
+.PHONY: coverage
+coverage: corpus
+# Runs the oracles without atheris, which would otherwise rewrite fickling's bytecode out
+# from under coverage.py.
+	$(UV_RUN) coverage run corpus_coverage.py corpus
+	$(UV_RUN) coverage html
+	@$(UV_RUN) coverage report | tail -1
+	@echo "coverage: file://$(CURDIR)/htmlcov/index.html"
+
+.PHONY: lint
+lint:
+# Ruff comes from the parent project, where it is a dev dependency; the config for these
+# files still comes from fuzz/pyproject.toml.
+	uv run --project .. ruff format --check .
+	uv run --project .. ruff check .
+
+.PHONY: clean
+clean:
+	rm -rf artifacts corpus htmlcov .coverage

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,246 @@
+# Fuzzing fickling's scanner
+
+A coverage-guided fuzzing harness for fickling's static analysis, pairing
+[atheris](https://github.com/google/atheris) with
+[cisco-ai-defense/pickle-fuzzer](https://github.com/cisco-ai-defense/pickle-fuzzer).
+
+Atheris supplies coverage feedback over instrumented Python; the pickle generator is a Rust
+extension that emits structurally valid pickles. Without the generator, a byte-level fuzzer
+spends nearly all its time on inputs fickling rejects in the first opcode. Without atheris,
+the generator has nothing telling it which pickles reached new code.
+
+**Manual only.** Nothing here runs in CI, and this is a separate uv project with its own
+lockfile and interpreter, so none of it reaches the published package or `make dev`.
+
+**Scanning only.** The harness never deserializes a pickle: every oracle parses, analyses
+and re-serializes, and the emitted reproducers do the same.
+
+## Setup
+
+Both dependencies are built from source, because neither ships a wheel that is usable here:
+the generator is a maturin/PyO3 extension not published to PyPI at all, and atheris publishes
+manylinux x86_64 wheels only -- so macOS and aarch64 always compile it, and the 3.1.0 release
+that supports Python 3.14 has no sdist, meaning PyPI cannot serve it off x86_64 at all. Hence
+clang, cargo, and the Python dev headers:
+
+```bash
+sudo apt install clang llvm python3-dev   # or: brew install llvm python
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+make env                     # uv sync -> fuzz/.venv, builds both deps
+make check                   # self-test: no fuzzing, ~1s
+```
+
+The dev headers are easy to miss: without them the build fails deep in a compiler log with
+`fatal error: 'Python.h' file not found`. uv-managed interpreters already have them, and uv
+fetches one itself, so this only bites against a system Python.
+
+**Python 3.14 only, by design.** Atheris rewrites bytecode for coverage and hard-gates on the
+versions it knows, and both dependencies are unreleased source builds. Pinning one
+interpreter keeps that combination reproducible instead of resolving differently per host.
+Nothing is lost: findings concern fickling's pickle parsing, which is not version-specific.
+
+## Its own uv project
+
+`fuzz/pyproject.toml` is a standalone project -- not a workspace member -- with its own
+`fuzz/uv.lock` and its own `.venv`. A uv workspace shares one lockfile and one virtualenv,
+and neither works here: syncing a 3.14-pinned fuzzer into a shared venv would clobber the
+dev environment, and a shared lock would put a git-pinned atheris in front of everyone who
+resolves fickling.
+
+The root `pyproject.toml` does not reference `fuzz/` at all; `uv lock` at the root resolves
+72 packages with no trace of atheris. The dependency on fickling goes the other way, as an
+editable path dependency on `..`, so the harness always fuzzes the working tree.
+
+Two consequences worth knowing:
+
+- Both git dependencies are pinned to an immutable rev. The generator uses its `v1.0.1` tag.
+  Atheris has no usable tag -- upstream's newest is `3.0.0`, which predates 3.13/3.14 support,
+  and the 3.1.0 that works here is untagged `main` -- so it is pinned to a commit SHA instead.
+  Worth revisiting if upstream ever tags 3.1.0.
+- `/fuzz` is in the sdist `exclude` list. Without it hatchling ships the whole directory,
+  corpus included, in every published release.
+
+Upstream's generator still declares `requires-python = ">=3.11,<3.12"`. That is stale
+metadata rather than a real limit: it is a pyo3 0.29 extension and builds and runs fine on
+3.14, verified here.
+
+## Running
+
+Everything below runs from this directory (`cd fuzz`), against `fuzz/Makefile`. Every target
+goes through `uv run`, which creates `.venv` from `uv.lock` on first use, so `make env` is
+optional -- useful only when you would rather pay for the source builds up front than inside
+the first run.
+
+```bash
+make help                    # the list below
+make fuzz                    # 60s, seeds a corpus on first run
+make fuzz ARGS='-max_total_time=3600 -jobs=4'
+make report                  # list what previous runs found
+make test                    # unit tests for the harness itself
+make coverage                # HTML report of what the corpus reaches
+make clean                   # drop corpus, findings and coverage output
+```
+
+`ARGS` is passed to libFuzzer, so `-max_len`, `-jobs`, `-rss_limit_mb`, `-timeout`, and
+friends all work. Useful ones:
+
+| Flag | Why |
+|---|---|
+| `-max_total_time=N` | Wall-clock budget for fuzzing. Minimization time is *additional*, so a run with many new findings overshoots. |
+| `-jobs=N` | Parallel workers. Each gets its own log. |
+| `-max_len=N` | Cap pickle size. Larger finds deeper nesting bugs, slower. |
+
+libFuzzer's own `-timeout` is not the hang detector here; it does not reliably interrupt
+pure-Python work, and one pathological pickle would otherwise stall the session and make
+`-max_total_time` meaningless. The harness enforces its own per-input ceiling instead
+(`--time-limit`, default 2s, `FICKLING_FUZZ_TIME_LIMIT` to change it) and reports anything
+slower as a finding. Set `--time-limit 0` to disable.
+
+Direct invocation, for the flags the Makefile does not cover. `uv run` picks up this
+directory's project and resolves the pinned interpreter, so there is no venv path to
+remember:
+
+```bash
+uv run python harness.py corpus -max_total_time=300
+uv run python harness.py --replay artifacts/*/minimal.pkl
+uv run python harness.py --help
+```
+
+From elsewhere in the repository, add `--project fuzz` and adjust the paths:
+`uv run --project fuzz python fuzz/harness.py fuzz/corpus -max_total_time=300`.
+
+## Coverage
+
+```bash
+make coverage                # writes fuzz/htmlcov/index.html
+```
+
+Replays every corpus input through the oracles under coverage.py and writes a browsable
+HTML report. libFuzzer's own `cov:` counter is an edge count with no source mapping -- it
+says coverage went up without saying of what -- so this is how you see which parts of
+fickling the corpus actually exercises, and which it never touches.
+
+It runs through `corpus_coverage.py` rather than `harness.py`, and so never imports atheris:
+atheris rewrites fickling's bytecode to insert its own counters, and measuring that with
+coverage.py reports the rewritten module rather than the source. Same oracles, same
+`scan.probe`, no fuzzer around them.
+
+Expect the analysis path to dominate and the rest to sit near zero -- roughly 70% of
+`fickle.py` and 80% of `analysis.py`, against 0% for `polyglot.py`, `pytorch.py` and
+`tracing.py`. That is the harness working as designed, not a gap in the corpus: the oracles
+take raw pickle bytes, so archive scanning, PyTorch model handling and the tracing
+interpreter are never entered. Treat those files as out of scope here rather than as
+coverage to chase.
+
+## Findings
+
+A run does **not** stop at the first crash. Fickling has a few failure modes reachable
+within the first second, so aborting on the first one would mean every session rediscovers
+the same bug and nothing else. Instead each distinct finding is reported once, minimized,
+and the run continues. Pass `--exit-on-finding` for the usual libFuzzer behaviour.
+
+Each finding gets `fuzz/artifacts/<signature>/`:
+
+| File | Contents |
+|---|---|
+| `report.md` | Traceback, disassembly of the minimized pickle, and an opcode-API skeleton for `test/test_bypasses.py` |
+| `minimal.pkl` | The delta-debugged pickle |
+| `original.pkl` | What the fuzzer originally produced |
+| `repro.py` | Standalone script that reproduces it, scanning only |
+
+Minimization is delta debugging over the pickle -- whole opcodes first, then individual
+bytes. A candidate is kept only if it reproduces the *same* signature, which matters
+because almost any truncation of a pickle produces *some* error. In practice a few-hundred
+byte input collapses to a handful of bytes.
+
+Signatures are `<exception>-<file>_<line>-<digest>`, where the digest covers the exception
+message with numbers, quoted fragments and heap addresses erased. Every part of that is
+load-bearing:
+
+- The **line** alone is not enough: `FLOAT` and `BYTEARRAY8` both raise from the same line
+  of `Opcode.__new__`, so only the message separates them.
+- The **erasure** is not optional: fickling interpolates the offending opcode's `repr` into
+  its messages, so the raw message carries a heap address and stream offset that differ on
+  every input. Keying on that files a fresh report per input and never converges.
+- The **oracle is excluded**: the oracles overlap, since `check_safety` builds the AST the
+  decompiler also walks. Shrinking an input often makes the same bug surface through an
+  earlier oracle, and keying on the oracle rejects those candidates as "a different bug",
+  blocking minimization outright.
+
+Hangs are the exception: they are keyed `Timeout-<oracle>`, because a timeout fires at an
+arbitrary line and the frame says where the clock ran out rather than where the cost is.
+
+Re-running does not re-report what is already in `artifacts/`. Delete a directory to have
+that finding surface again, and `make report` to list them.
+
+### What counts as a finding
+
+`scan.EXPECTED_EXCEPTIONS` encodes fickling's documented contract: malformed input raises
+`PickleDecodeError`, resource limits raise `ResourceExhaustionError`. Anything else
+escaping an oracle is a finding, because callers such as `fickling.load()` are not written
+to survive it.
+
+Three oracles run per input, cheapest first:
+
+- **`scan`** -- `StackedPickle.load` then `check_safety` on each pickle, plus `to_dict()`,
+  which the CLI and any programmatic caller depend on.
+- **`roundtrip`** -- `dumps()` must be stable under re-parsing. Security-relevant, not
+  cosmetic: `fickling.load()` analyses the parsed form but executes `dumps()` output, so
+  drift there means analysis and execution disagree about what the pickle is.
+- **`decompile`** -- `str(pickled.ast)` must not fall over on anything that parsed.
+
+To mute a known finding without editing code:
+
+```bash
+FICKLING_FUZZ_EXPECTED=NotImplementedError make fuzz
+FICKLING_FUZZ_VERBOSE=1 ...          # show fickling's own stderr diagnostics
+```
+
+### Findings present on master
+
+A first run rediscovers these immediately. They are pre-existing, unrelated to the harness,
+and left alone here:
+
+- `NotImplementedError` from `Opcode.__new__` for the four opcodes with no fickling class:
+  `FLOAT`, `BYTEARRAY8`, `NEXT_BUFFER`, `READONLY_BUFFER`. Reaches callers instead of the
+  documented `PickleDecodeError`.
+- `AttributeError`, `IndexError` and `ValueError` out of `check_safety` and the decompiler on
+  malformed streams.
+- `Timeout-scan`: inputs where analysis runs for seconds. Fickling has resource limits but no
+  wall clock, so the ceiling that catches these is the harness's.
+
+Two unrelated things also worth knowing, since both show up the moment you build the env:
+
+- `fickling/fickle.py` imports `typing_extensions.Buffer` below Python 3.12, but
+  `typing-extensions` is declared only in the `lint` extra rather than in
+  `[project] dependencies`, so `pip install fickling` is not importable on 3.10 or 3.11.
+  Pinning this project to 3.14 sidesteps it; the bug is still there for anyone else.
+- Six sites in `fickle.py` write `Warning: malformed pickle file...` straight to
+  `sys.stderr`, which `CLAUDE.md` reserves for `cli.py`. At a few hundred executions a second
+  that buries the harness output, so `scan.py` suppresses it unless
+  `FICKLING_FUZZ_VERBOSE=1`.
+
+## Layout
+
+```
+fuzz/
+  pyproject.toml   the separate uv project: pinned deps, interpreter, ruff overrides
+  uv.lock          its own lock; the parent's is untouched
+  Makefile         every target, all via `uv run`
+  harness.py       atheris entry point, custom mutator, CLI
+  scan.py          the oracles, what counts as a finding, signatures
+  triage.py        delta debugging and reproducer artifacts
+  corpus_coverage.py  corpus replay under coverage.py, atheris deliberately absent
+  tests/           unit tests for the above; needs neither atheris nor the generator
+```
+
+Modules are imported by path rather than as a package, so `harness.py` is runnable
+directly and the tests can import the modules without installing anything.
+
+The generator is wired in as an atheris `custom_mutator` rather than called from inside the
+test function. That keeps libFuzzer's corpus in *pickle space*: corpus entries and crash
+artifacts are themselves pickles, coverage is attributed to real pickle structure, and
+`-minimize_crash=1` works natively. 15% of mutations are plain byte mutations rather than
+generated pickles, which is how the harness keeps reaching fickling's malformed-input
+paths -- a generator that only emits well-formed pickles would never test them.

--- a/fuzz/corpus_coverage.py
+++ b/fuzz/corpus_coverage.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Replay a corpus through the oracles so coverage.py can measure what it reaches.
+
+libFuzzer's own ``cov:`` counter is an edge count with no source mapping, so it says
+coverage went up without saying of what.
+
+Does not import ``harness``, and so never imports atheris: atheris rewrites fickling's
+bytecode to insert its own counters, and coverage.py would then measure the rewritten
+module rather than the source. Same inputs, same `scan.probe`, no fuzzer around them.
+
+    make coverage
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import scan
+
+HERE = Path(__file__).resolve().parent
+
+
+def replay(paths: list[Path]) -> tuple[int, int]:
+    """Probe every input, returning (probed, findings)."""
+    findings = 0
+    for path in paths:
+        if scan.probe(path.read_bytes()) is not None:
+            findings += 1
+    return len(paths), findings
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="corpus_coverage.py", description=__doc__)
+    parser.add_argument(
+        "corpus",
+        type=Path,
+        nargs="*",
+        default=[HERE / "corpus"],
+        help="corpus directories or individual pickles (default: fuzz/corpus)",
+    )
+    parser.add_argument(
+        "--time-limit",
+        type=float,
+        default=scan.DEFAULT_TIME_LIMIT,
+        metavar="SECONDS",
+        help=(
+            "per-input ceiling, as in the harness; corpora accumulate slow inputs "
+            f"(default: {scan.DEFAULT_TIME_LIMIT})"
+        ),
+    )
+    args = parser.parse_args(argv[1:])
+    scan.DEFAULT_TIME_LIMIT = args.time_limit
+
+    paths: list[Path] = []
+    for entry in args.corpus:
+        if entry.is_dir():
+            paths.extend(sorted(p for p in entry.rglob("*") if p.is_file()))
+        elif entry.is_file():
+            paths.append(entry)
+        else:
+            print(f"corpus_coverage: no such path: {entry}", file=sys.stderr)
+            return 2
+
+    if not paths:
+        print(
+            "corpus_coverage: nothing to replay. Seed a corpus first: make fuzz",
+            file=sys.stderr,
+        )
+        return 2
+
+    probed, findings = replay(paths)
+    print(f"replayed {probed} input(s); {findings} reproduced a finding")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/fuzz/harness.py
+++ b/fuzz/harness.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Structure-aware fuzzing harness for fickling's pickle scanner.
+
+Pairs atheris (coverage feedback over instrumented Python) with
+cisco-ai-defense/pickle-fuzzer (a Rust generator of structurally valid pickles). The
+generator is wired in as an atheris ``custom_mutator`` rather than called from the test
+function, which keeps libFuzzer's corpus in pickle space: corpus entries and crash
+artifacts are themselves pickles, and ``-minimize_crash=1`` works natively.
+
+    make fuzz               # 60s smoke run
+    make fuzz ARGS='-max_total_time=600 -jobs=4'
+    make check              # self-test, no fuzzing
+
+Findings land in fuzz/artifacts/<signature>/ with a minimized pickle and a reproducer.
+Nothing here deserializes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import shlex
+import sys
+from pathlib import Path
+
+import atheris
+
+# Without instrumentation there is no coverage signal to guide on. Scoped to the package
+# because instrumenting the world is slow and buys nothing here.
+with atheris.instrument_imports(include=["fickling"]):
+    import fickling  # noqa: F401 - imported for its instrumentation side effect
+
+from pickle_fuzzer import Generator
+
+import scan
+import triage
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_ARTIFACTS = HERE / "artifacts"
+PROTOCOLS = 6
+
+#: Share of mutations that come from the generator. The rest are plain byte mutations,
+#: which is how fickling's malformed-input paths get reached at all.
+STRUCTURED_SHARE = 0.85
+
+_generators: dict[int, Generator] = {}
+
+
+def _generate(protocol: int, seed_bytes: bytes, max_size: int) -> bytes:
+    """Structure-aware generation, reusing one Generator per protocol.
+
+    ``reset()`` keeps generation a pure function of (protocol, seed_bytes). Without it a
+    crash found now would not replay later, and the minimizer would chase a moving target.
+    """
+    gen = _generators.get(protocol)
+    if gen is None:
+        gen = _generators[protocol] = Generator(protocol=protocol, seed=protocol)
+    gen.reset()
+    return gen.generate_from_bytes(seed_bytes, max_size=max_size)
+
+
+def custom_mutator(data: bytes, max_size: int, seed: int) -> bytes:
+    """Produce the next candidate pickle. Deterministic in (data, max_size, seed), which
+    libFuzzer requires for replay."""
+    rng = random.Random(seed)
+    if rng.random() < STRUCTURED_SHARE:
+        protocol = rng.randrange(PROTOCOLS)
+        try:
+            return _generate(protocol, data or bytes([seed & 0xFF]), max_size)
+        except Exception:  # noqa: BLE001 - fall through to byte mutation
+            pass
+    mutated = atheris.Mutate(data, max_size) if data else bytes([seed & 0xFF])
+    return mutated[:max_size]
+
+
+def make_test_one_input(
+    artifacts: Path, minimize: bool, exit_on_finding: bool, minimize_time: float
+):
+    """Build the fuzz target; `data` arrives as pickle bytes from `custom_mutator`.
+
+    A finding does not stop the run by default. Fickling has failure modes reachable within
+    the first second, so aborting on the first would rediscover the same bug every session.
+    """
+    # Signatures already on disk from an earlier session, so re-runs do not re-report.
+    seen: set[str] = (
+        {p.name for p in artifacts.iterdir() if p.is_dir()} if artifacts.exists() else set()
+    )
+    if seen:
+        print(
+            f"{len(seen)} known finding(s) in {artifacts}; delete a directory to have it "
+            "reported again",
+            file=sys.stderr,
+        )
+
+    def test_one_input(data: bytes) -> None:
+        failure = scan.probe(data)
+        if failure is None:
+            return
+        # Dedup before minimizing: delta debugging is by far the expensive part.
+        if failure.signature not in seen:
+            seen.add(failure.signature)
+            minimal = (
+                triage.minimize(data, failure, time_budget=minimize_time) if minimize else data
+            )
+            written = triage.emit(artifacts, data, minimal, failure)
+            print(
+                f"\n=== finding {len(seen)}: {failure}\n"
+                f"    minimized {len(data)} -> {len(minimal)} bytes\n"
+                f"    {written or artifacts / failure.signature}/report.md",
+                file=sys.stderr,
+                flush=True,
+            )
+        # Outside the dedup: -minimize_crash and artifact replay feed back an input whose
+        # signature is already on disk, and swallowing the raise there makes a real crash
+        # look clean ("the input did not crash"). Reporting dedups, the crash signal does not.
+        if exit_on_finding:
+            raise failure.exc
+
+    return test_one_input
+
+
+def _write_corpus(corpus: Path) -> int:
+    """Seed a corpus of valid pickles across all six protocols, so coverage climbs
+    immediately instead of after a few million rejections."""
+    corpus.mkdir(parents=True, exist_ok=True)
+    written = 0
+    for protocol in range(PROTOCOLS):
+        for i in range(8):
+            try:
+                data = _generate(protocol, bytes([protocol, i]) * (i + 1), 512)
+            except Exception:  # noqa: BLE001
+                continue
+            (corpus / f"seed-p{protocol}-{i:02d}.pkl").write_bytes(data)
+            written += 1
+    return written
+
+
+def _self_check() -> int:
+    """Prove the harness works without fuzzing: the oracles behave and the generator runs."""
+    benign = b"\x80\x04K\x01."  # PROTO 4, BININT1 1, STOP
+    if scan.probe(benign) is not None:
+        print("FAIL: a benign pickle was reported as a finding", file=sys.stderr)
+        return 1
+    print("oracles: benign pickle passes")
+
+    if scan.probe(b"\x80\x04garbage-not-a-pickle") is not None:
+        print("FAIL: malformed input should be an expected rejection", file=sys.stderr)
+        return 1
+    print("oracles: malformed input is rejected, not reported")
+
+    generated = _generate(4, b"self-check", 256)
+    print(f"generator: produced {len(generated)} bytes of protocol-4 pickle")
+    print("\nself-check passed")
+    return 0
+
+
+def _relaunch_command(args: argparse.Namespace) -> str:
+    """``argv[0]`` for the children libFuzzer spawns for -jobs, -fork and -minimize_crash.
+
+    Those re-launch the target through ``sh`` instead of forking, rebuilding the command
+    line from the flags libFuzzer itself knows. So two things break: ``sys.argv[0]`` is a
+    script path that is neither on PATH nor executable, and this harness's own options never
+    reach the child, leaving workers writing to the wrong artifacts directory and ignoring
+    --exit-on-finding. Naming the interpreter and re-appending the options fixes both, and
+    quoting survives the round trip through ``sh``, which word-splits the result back.
+    """
+    parts = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--artifacts",
+        str(args.artifacts),
+        "--time-limit",
+        str(args.time_limit),
+    ]
+    if args.no_minimize:
+        parts.append("--no-minimize")
+    if args.exit_on_finding:
+        parts.append("--exit-on-finding")
+    if args.minimize_time is not None:
+        parts += ["--minimize-time", str(args.minimize_time)]
+    return " ".join(shlex.quote(part) for part in parts)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="harness.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+    parser.add_argument("--artifacts", type=Path, default=DEFAULT_ARTIFACTS)
+    parser.add_argument("--no-minimize", action="store_true", help="skip delta debugging")
+    parser.add_argument(
+        "--exit-on-finding",
+        action="store_true",
+        help="stop at the first new finding and let libFuzzer record it as a crash",
+    )
+    parser.add_argument(
+        "--minimize-time",
+        type=float,
+        metavar="SECONDS",
+        help="per-finding delta debugging budget (default: 5 while fuzzing, 60 for --replay)",
+    )
+    parser.add_argument(
+        "--time-limit",
+        type=float,
+        default=scan.DEFAULT_TIME_LIMIT,
+        metavar="SECONDS",
+        help=(
+            "per-input wall-clock ceiling; exceeding it is reported as a hang "
+            f"(default: {scan.DEFAULT_TIME_LIMIT}, 0 disables)"
+        ),
+    )
+    parser.add_argument("--check", action="store_true", help="self-test and exit")
+    parser.add_argument("--summary", action="store_true", help="list recorded findings and exit")
+    parser.add_argument("--write-corpus", type=Path, metavar="DIR", help="seed a corpus and exit")
+    parser.add_argument(
+        "--replay", type=Path, nargs="+", metavar="FILE", help="scan saved pickles and exit"
+    )
+    args, libfuzzer_args = parser.parse_known_args(argv[1:])
+
+    # Applies to the minimizer's probes too, so one slow candidate cannot stall it.
+    scan.DEFAULT_TIME_LIMIT = args.time_limit
+
+    if args.check:
+        return _self_check()
+
+    if args.summary:
+        return _summary(args.artifacts)
+
+    if args.write_corpus:
+        count = _write_corpus(args.write_corpus)
+        print(f"wrote {count} seeds to {args.write_corpus}")
+        return 0
+
+    if args.replay:
+        # One-shot triage can afford to minimize far harder than the fuzz loop, where this
+        # time is spent per finding on top of -max_total_time.
+        budget = args.minimize_time if args.minimize_time is not None else 60.0
+        return _replay(args.replay, args.artifacts, not args.no_minimize, budget)
+
+    args.artifacts.mkdir(parents=True, exist_ok=True)
+    target = make_test_one_input(
+        args.artifacts,
+        not args.no_minimize,
+        args.exit_on_finding,
+        args.minimize_time if args.minimize_time is not None else 5.0,
+    )
+    # Keep libFuzzer's own crash/timeout units next to our reports instead of in the cwd.
+    if not any(a.startswith("-artifact_prefix=") for a in libfuzzer_args):
+        libfuzzer_args.append(f"-artifact_prefix={args.artifacts}/")
+    atheris.Setup([_relaunch_command(args), *libfuzzer_args], target, custom_mutator=custom_mutator)
+    # Does not return: libFuzzer exits the process itself, without unwinding Python. Anything
+    # worth reporting has to be printed as it is found; `--summary` recaps afterwards.
+    atheris.Fuzz()
+    return 0
+
+
+def _summary(artifacts: Path) -> int:
+    """List the findings recorded so far."""
+    found = sorted(p for p in artifacts.iterdir() if p.is_dir()) if artifacts.exists() else []
+    if not found:
+        print(f"no findings in {artifacts}")
+        return 0
+    print(f"{len(found)} finding(s) in {artifacts}:\n")
+    for path in found:
+        minimal = path / "minimal.pkl"
+        size = f"{len(minimal.read_bytes())}b" if minimal.exists() else "?"
+        print(f"  {path.name}  ({size} minimized)")
+    return 0
+
+
+def _replay(paths: list[Path], artifacts: Path, minimize: bool, minimize_time: float) -> int:
+    """Re-scan saved pickles and re-emit their reports. The triage entry point."""
+    findings = 0
+    for path in paths:
+        data = path.read_bytes()
+        failure = scan.probe(data)
+        if failure is None:
+            print(f"{path}: clean")
+            continue
+        findings += 1
+        minimal = triage.minimize(data, failure, time_budget=minimize_time) if minimize else data
+        written = triage.emit(artifacts, data, minimal, failure)
+        where = f" -> {written}/report.md" if written else " (already reported)"
+        print(f"{path}: {failure} [{len(data)} -> {len(minimal)} bytes]{where}")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/fuzz/pyproject.toml
+++ b/fuzz/pyproject.toml
@@ -1,0 +1,60 @@
+# A separate uv project, deliberately not a workspace member of the parent: a workspace
+# shares one lockfile and one venv, and syncing a 3.14-pinned fuzzer into the shared venv
+# would clobber `make dev`. Nothing in the parent references this file.
+#
+# Needs clang, cargo and the Python dev headers; see README.md.
+
+[project]
+name = "fickling-fuzz"
+version = "0"
+description = "Coverage-guided fuzzing harness for fickling's pickle scanner"
+# One interpreter, not a range: atheris hard-gates on the versions it knows and both
+# dependencies are source builds, so pinning keeps that combination reproducible. Stating it
+# here is the point of the split -- the parent's >=3.10 range no longer has to stay
+# resolvable against atheris.
+requires-python = ">=3.14,<3.15"
+dependencies = [
+  "fickling[archive]",
+  # From git, not PyPI: atheris ships manylinux x86_64 wheels only, and the 3.1.0 release
+  # that supports 3.14 has no sdist, so PyPI cannot serve it off x86_64 at all.
+  #
+  # Pinned to a commit so a rebuild resolves what was tested. A tag would be better, but
+  # upstream's newest is 3.0.0 and predates 3.14 support; 3.1.0 exists only as untagged main.
+  "atheris @ git+https://github.com/google/atheris@e36da74cf42b5834c4e31d7cabb58d796695d29f",
+  # Upstream's requires-python of ">=3.11,<3.12" is stale metadata, not a real limit: it is a
+  # pyo3 0.29 extension and builds and runs fine on 3.14.
+  "cisco-ai-defense-pickle-fuzzer @ git+https://github.com/cisco-ai-defense/pickle-fuzzer@v1.0.1",
+  "pytest >= 8.0.0",
+  "coverage[toml] >= 7.0.0",  # make coverage
+]
+
+[tool.coverage.run]
+branch = true
+source = ["fickling"]
+# The oracles never invoke the CLI, so counting it would only dilute the percentage.
+omit = ["*/fickling/__main__.py", "*/fickling/cli.py"]
+
+[tool.coverage.html]
+directory = "htmlcov"
+
+[tool.coverage.report]
+skip_empty = true
+
+[tool.uv]
+# Virtual project: the harness modules are imported by path, so there is nothing to build.
+package = false
+
+[tool.uv.sources]
+# Always the working tree, never PyPI: the point is to fuzz the code under edit.
+fickling = { path = "..", editable = true }
+
+[tool.ruff]
+# Inherits the parent's line length, rules and format settings. Not its target-version:
+# ruff infers py314 from requires-python above, which is what we want here -- this project
+# never has to import under the parent's 3.10+ range.
+extend = "../pyproject.toml"
+
+[tool.ruff.lint]
+# The harness reports findings to the operator (T20), and its modules are imported by path
+# after atheris' instrumentation hook runs (E402).
+extend-ignore = ["T20", "E402"]

--- a/fuzz/scan.py
+++ b/fuzz/scan.py
@@ -1,0 +1,240 @@
+"""What the harness asserts about fickling, and what counts as a finding.
+
+Pure static analysis throughout: parse, analyse, re-serialize, never deserialize.
+
+A finding is any exception outside `EXPECTED_EXCEPTIONS` escaping an oracle. Those encode
+fickling's documented contract, so anything else reaching a caller is a contract violation
+by definition -- callers such as ``fickling.load()`` are not written to survive it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import os
+import re
+import signal
+import traceback
+from collections.abc import Callable
+from dataclasses import dataclass
+from io import BytesIO, StringIO
+
+from fickling.analysis import check_safety
+from fickling.exception import ResourceExhaustionError
+from fickling.fickle import Pickled, PickleDecodeError, StackedPickle
+
+#: Fickling's documented contract for bad input. `PickleDecodeError` covers
+#: `EmptyPickleError` and `InterpretationError`. FICKLING_FUZZ_EXPECTED extends this at
+#: runtime, to mute a known finding without editing the file.
+EXPECTED_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    PickleDecodeError,
+    ResourceExhaustionError,
+)
+
+
+class OracleViolationError(AssertionError):
+    """An invariant the harness checks itself, as opposed to an exception fickling raised."""
+
+
+class ScanTimeout(BaseException):
+    """Raised when an input exceeds the per-input wall-clock budget.
+
+    `BaseException`, because fickling catches ``Exception`` broadly and a hang must not be
+    absorbed into a clean scan.
+    """
+
+
+#: Per-input wall-clock ceiling; exceeding it is itself a finding. libFuzzer's ``-timeout``
+#: does not reliably interrupt pure-Python work, so without this one slow pickle stalls the
+#: session and ``-max_total_time`` stops meaning anything.
+DEFAULT_TIME_LIMIT = float(os.environ.get("FICKLING_FUZZ_TIME_LIMIT", "2.0"))
+
+_CAN_SET_ALARM = hasattr(signal, "SIGALRM") and hasattr(signal, "setitimer")
+
+
+@contextlib.contextmanager
+def time_limit(seconds: float):
+    """Abort the enclosed block after `seconds` of wall clock.
+
+    SIGALRM, so POSIX main thread only -- which is where libFuzzer runs the target.
+    Degrades to no limit elsewhere.
+    """
+    if seconds <= 0 or not _CAN_SET_ALARM:
+        yield
+        return
+
+    def _fire(_signum, _frame):
+        raise ScanTimeout(f"exceeded the {seconds}s per-input limit")
+
+    previous = signal.signal(signal.SIGALRM, _fire)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous)
+
+
+def _muted_names() -> frozenset[str]:
+    return frozenset(
+        n.strip() for n in os.environ.get("FICKLING_FUZZ_EXPECTED", "").split(",") if n.strip()
+    )
+
+
+def _quiet():
+    """Swallow fickling's own stderr diagnostics for one oracle call.
+
+    ``fickle.py`` writes "Warning: malformed pickle file..." directly to stderr; at a few
+    hundred execs a second that buries the harness's output. FICKLING_FUZZ_VERBOSE=1 keeps it.
+    """
+    if os.environ.get("FICKLING_FUZZ_VERBOSE"):
+        return contextlib.nullcontext()
+    return contextlib.redirect_stderr(StringIO())
+
+
+# --- oracles ---------------------------------------------------------------------------
+# Each takes raw pickle bytes and raises on violation. Ordered cheapest-first; `probe`
+# stops at the first one that rejects the input.
+
+
+def oracle_scan(data: bytes) -> None:
+    """Parse every pickle in the stream and analyse each. ``to_dict()`` is asserted too,
+    since ``fickling --json`` and programmatic callers depend on it."""
+    for pickled in StackedPickle.load(BytesIO(data), fail_on_decode_error=True):
+        result = check_safety(pickled)
+        if result.severity is None:
+            raise OracleViolationError("check_safety returned a result with severity=None")
+        result.to_dict()
+
+
+def oracle_roundtrip(data: bytes) -> None:
+    """``dumps()`` must be stable under re-parsing.
+
+    Security-relevant, not cosmetic: ``fickling.load()`` analyses the parsed form but
+    executes ``dumps()``, so drift means analysis and execution disagree about what the
+    pickle is.
+    """
+    first = Pickled.load(BytesIO(data), fail_on_decode_error=True)
+    if first.has_invalid_opcode:
+        # The stream carries opcodes fickling could not model, so it makes no promise
+        # about reproducing them byte-for-byte.
+        return
+    once = first.dumps()
+    twice = Pickled.load(BytesIO(once), fail_on_decode_error=True).dumps()
+    if once != twice:
+        raise OracleViolationError(
+            f"dumps() is not stable under re-parsing: {len(once)} bytes became {len(twice)}"
+        )
+
+
+def oracle_decompile(data: bytes) -> None:
+    """The decompiler must not fall over on anything that parsed."""
+    pickled = Pickled.load(BytesIO(data), fail_on_decode_error=True)
+    str(pickled.ast)
+
+
+ORACLES: tuple[tuple[str, Callable[[bytes], None]], ...] = (
+    ("scan", oracle_scan),
+    ("roundtrip", oracle_roundtrip),
+    ("decompile", oracle_decompile),
+)
+
+
+# --- running them ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Failure:
+    """A single oracle failure, with a signature stable enough to minimize against."""
+
+    oracle: str
+    exc: BaseException
+    signature: str
+    traceback: str
+
+    def __str__(self) -> str:
+        return f"[{self.oracle}] {type(self.exc).__name__}: {self.exc}"
+
+
+_FICKLING_FRAME = re.compile(r"[/\\]fickling[/\\]([\w.]+\.py)$")
+_QUOTED = re.compile(r"""(['"]).*?\1""")
+#: Must be erased before digits: an address is not a digit run, so digit-stripping alone
+#: leaves it varying, and fickling's messages embed object reprs freely.
+_ADDRESS = re.compile(r"0x[0-9a-fA-F]+")
+_DIGITS = re.compile(r"\d+")
+_UNSAFE_IN_PATH = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def normalize_message(message: str) -> str:
+    """Reduce an exception message to the part that identifies the *bug*, not the input.
+
+    Two competing needs. Distinct bugs must not collapse: FLOAT and BYTEARRAY8 both raise
+    from the same line of ``Opcode.__new__``, so only the message separates them. But the
+    same bug must not fragment: fickling interpolates the offending opcode's repr, so raw
+    messages carry addresses and offsets that differ on every input.
+
+    Erasing quoted fragments, addresses and numbers keeps what names the bug -- the opcode
+    class, the failed expectation, the AST node type.
+    """
+    collapsed = _QUOTED.sub("'?'", message)
+    collapsed = _ADDRESS.sub("0x?", collapsed)
+    collapsed = _DIGITS.sub("#", collapsed)
+    return " ".join(collapsed.split())[:120]
+
+
+def signature(exc: BaseException, oracle: str = "") -> str:
+    """Identify *which bug* this is, so minimization cannot silently drift to another one.
+
+    Keyed on the deepest frame inside fickling plus a digest of the normalized message.
+    Stable within a run but not across edits, which is the right scope -- it only compares
+    candidates during one minimization. Safe as a directory name.
+
+    Excludes the oracle deliberately: the oracles overlap, so shrinking often makes the same
+    bug surface through an earlier one, and keying on it would reject those candidates as a
+    different bug and block minimization outright.
+    """
+    if isinstance(exc, ScanTimeout):
+        # A timeout fires at an arbitrary point, so the frame says where the clock ran out,
+        # not where the cost is. Collapse every hang in one oracle into one finding.
+        return f"Timeout-{oracle or 'unknown'}"
+
+    site = "unknown"
+    for frame in reversed(traceback.extract_tb(exc.__traceback__)):
+        match = _FICKLING_FRAME.search(frame.filename)
+        if match:
+            site = f"{match.group(1)}:{frame.lineno}"
+            break
+    digest = hashlib.blake2b(
+        normalize_message(str(exc)).encode("utf-8", "replace"), digest_size=4
+    ).hexdigest()
+    return _UNSAFE_IN_PATH.sub("_", f"{type(exc).__name__}-{site}-{digest}")
+
+
+def probe(data: bytes, oracles=ORACLES, time_limit_seconds: float | None = None) -> Failure | None:
+    """Run the oracles over `data`. Return the first `Failure`, or None if it behaved.
+
+    Returns rather than raises so the minimizer can compare thousands of candidates
+    without exception-handling gymnastics.
+    """
+    muted = _muted_names()
+    limit = DEFAULT_TIME_LIMIT if time_limit_seconds is None else time_limit_seconds
+    for name, fn in oracles:
+        try:
+            with time_limit(limit), _quiet():
+                fn(data)
+        except EXPECTED_EXCEPTIONS:
+            # Not a valid pickle, or a deliberate limit. Later oracles would only re-derive
+            # the same rejection.
+            return None
+        except KeyboardInterrupt, SystemExit:
+            raise
+        except BaseException as exc:  # noqa: BLE001 - triaging arbitrary failures is the job
+            if type(exc).__name__ in muted or any(c.__name__ in muted for c in type(exc).__mro__):
+                return None
+            return Failure(
+                oracle=name,
+                exc=exc,
+                signature=signature(exc, name),
+                traceback="".join(traceback.format_exception(exc)),
+            )
+    return None

--- a/fuzz/tests/test_harness.py
+++ b/fuzz/tests/test_harness.py
@@ -1,0 +1,346 @@
+"""Tests for the fuzzing harness itself.
+
+Imports neither atheris nor the generator, so ``make test`` covers them without a fuzzing
+run. Still this project's 3.14 venv, though -- not the parent's.
+"""
+
+import sys
+import time
+import unittest
+import unittest.mock
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import fickling.fickle as op
+import scan
+import triage
+from fickling.fickle import Pickled
+
+BENIGN = Pickled([op.Proto.create(4), op.BinInt1(1), op.Stop()]).dumps()
+
+
+class TestOracles(unittest.TestCase):
+    def test_benign_pickle_is_not_a_finding(self):
+        self.assertIsNone(scan.probe(BENIGN))
+
+    def test_malformed_input_is_expected_not_reported(self):
+        # A decode error is fickling's documented contract for garbage, not a bug.
+        self.assertIsNone(scan.probe(b"\x80\x04not-a-pickle-at-all"))
+
+    def test_empty_input_is_not_a_finding(self):
+        self.assertIsNone(scan.probe(b""))
+
+    def test_unexpected_exception_is_reported(self):
+        # FLOAT has no fickling Opcode class, so parsing raises NotImplementedError rather
+        # than the documented PickleDecodeError. Used here as a stable known-bad input.
+        failure = scan.probe(b"F1.0\n.")
+        self.assertIsNotNone(failure)
+        self.assertEqual(failure.oracle, "scan")
+        self.assertIn("NotImplementedError", failure.signature)
+
+    def test_muting_via_env(self):
+        with unittest.mock.patch.dict(
+            "os.environ", {"FICKLING_FUZZ_EXPECTED": "NotImplementedError"}
+        ):
+            self.assertIsNone(scan.probe(b"F1.0\n."))
+
+    def test_signature_distinguishes_distinct_bugs_at_the_same_line(self):
+        # FLOAT and BYTEARRAY8 both raise NotImplementedError from the same line of
+        # Opcode.__new__, so the frame alone cannot separate them. They must not collapse,
+        # or only the first would ever be reported.
+        float_sig = scan.probe(b"F1.0\n.").signature
+        bytearray_sig = scan.probe(b"\x80\x05\x96\x01\x00\x00\x00\x00\x00\x00\x00a.").signature
+        self.assertNotEqual(float_sig, bytearray_sig)
+
+    def test_signature_is_usable_as_a_directory_name(self):
+        sig = scan.probe(b"F1.0\n.").signature
+        self.assertNotIn("/", sig)
+        self.assertNotIn(":", sig)
+
+    def test_normalize_message_collapses_input_derived_values(self):
+        # Same bug, different integer: one report, not one per integer the fuzzer finds.
+        self.assertEqual(
+            scan.normalize_message("BINGET references non-existent memo key 2"),
+            scan.normalize_message("BINGET references non-existent memo key 34567"),
+        )
+
+    def test_normalize_message_collapses_heap_addresses(self):
+        # Fickling interpolates object reprs into messages. Without erasing the address the
+        # same bug gets a brand new signature on every run and never converges.
+        self.assertEqual(
+            scan.normalize_message("found <ast.Tuple object at 0xffffb7ea80d0>"),
+            scan.normalize_message("found <ast.Tuple object at 0xffffb7ea8370>"),
+        )
+
+    def test_normalize_message_collapses_opcode_repr_noise(self):
+        # Same opcode, different stream offset and payload: one bug.
+        self.assertEqual(
+            scan.normalize_message(
+                "Opcode Pop(info=<pickletools.OpcodeInfo object at 0xaaaa>, "
+                "data=b'0', position=1132) attempted to pop from an empty stack"
+            ),
+            scan.normalize_message(
+                "Opcode Pop(info=<pickletools.OpcodeInfo object at 0xbbbb>, "
+                "data=b'1', position=77) attempted to pop from an empty stack"
+            ),
+        )
+
+    def test_normalize_message_keeps_the_ast_node_type(self):
+        # ast.Tuple and ast.Constant are different paths through the decompiler.
+        self.assertNotEqual(
+            scan.normalize_message("found <ast.Tuple object at 0xffffb7ea80d0>"),
+            scan.normalize_message("found <ast.Constant object at 0xffffb7ea80d0>"),
+        )
+
+    def test_normalize_message_keeps_distinguishing_words(self):
+        self.assertNotEqual(
+            scan.normalize_message("TODO: Add support for Opcode FLOAT"),
+            scan.normalize_message("TODO: Add support for Opcode BYTEARRAY8"),
+        )
+
+    def test_roundtrip_oracle_accepts_valid_pickles(self):
+        for protocol in range(6):
+            with self.subTest(protocol=protocol):
+                data = Pickled([op.BinInt1(7), op.Stop()]).dumps()
+                scan.oracle_roundtrip(data)  # must not raise
+
+
+class TestTimeLimit(unittest.TestCase):
+    """A scanner with no wall clock can be hung by one input, and without this the harness
+    itself stalls and libFuzzer's -max_total_time stops meaning anything."""
+
+    def test_slow_work_is_interrupted(self):
+        def slow(_data):
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                pass
+
+        started = time.monotonic()
+        failure = scan.probe(BENIGN, oracles=(("slow", slow),), time_limit_seconds=0.3)
+        elapsed = time.monotonic() - started
+
+        self.assertIsNotNone(failure, "a hang must be reported, not silently allowed")
+        self.assertIsInstance(failure.exc, scan.ScanTimeout)
+        self.assertLess(elapsed, 5, "the limit did not actually interrupt the work")
+
+    def test_timeout_signature_collapses_interruption_points(self):
+        # A timeout fires at an arbitrary line, so keying on the frame would file a fresh
+        # report every time. All hangs in one oracle are one finding.
+        def slow(_data):
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                pass
+
+        first = scan.probe(BENIGN, oracles=(("slow", slow),), time_limit_seconds=0.2)
+        second = scan.probe(BENIGN, oracles=(("slow", slow),), time_limit_seconds=0.25)
+        self.assertEqual(first.signature, second.signature)
+        self.assertEqual(first.signature, "Timeout-slow")
+
+    def test_timeout_survives_except_exception(self):
+        # Fickling catches Exception broadly; a hang must not be absorbed into a clean scan.
+        self.assertFalse(issubclass(scan.ScanTimeout, Exception))
+
+    def test_limit_is_disarmed_afterwards(self):
+        scan.probe(BENIGN, time_limit_seconds=5)
+        # If the itimer were left running, this sleep would be interrupted.
+        time.sleep(0.05)
+
+    def test_zero_disables_the_limit(self):
+        self.assertIsNone(scan.probe(BENIGN, time_limit_seconds=0))
+
+
+class TestMinimizer(unittest.TestCase):
+    def test_minimizes_to_the_essential_opcode(self):
+        padding = [op.BinInt1(i % 256) for i in range(40)]
+        noisy = Pickled([op.Proto.create(2), *padding, op.Stop()]).dumps() + b"F1.0\n."
+        failure = scan.probe(noisy)
+        self.assertIsNotNone(failure)
+
+        minimal = triage.minimize(noisy, failure)
+        self.assertLess(len(minimal), len(noisy))
+        # Same bug, still reproducing.
+        self.assertEqual(scan.probe(minimal).signature, failure.signature)
+
+    def test_minimize_preserves_signature_and_never_grows(self):
+        data = b"\x80\x04" + b"K\x01" * 30 + b"F1.0\n."
+        failure = scan.probe(data)
+        minimal = triage.minimize(data, failure)
+        self.assertLessEqual(len(minimal), len(data))
+        self.assertEqual(scan.probe(minimal).signature, failure.signature)
+
+    def test_opcode_units_returns_none_for_garbage(self):
+        self.assertIsNone(triage._opcode_units(b"\xff\xfe\xfd"))
+
+    def test_opcode_units_covers_the_whole_input(self):
+        units = triage._opcode_units(BENIGN)
+        self.assertIsNotNone(units)
+        self.assertEqual(b"".join(units), BENIGN)
+
+
+class TestReproducerArtifacts(unittest.TestCase):
+    def test_snippet_is_verified_for_a_supported_pickle(self):
+        snippet, exact = triage.opcode_api_snippet(BENIGN)
+        self.assertTrue(exact, f"expected an exact rebuild, got:\n{snippet}")
+        self.assertIn("op.Proto.create(4)", snippet)
+        self.assertIn("op.Stop()", snippet)
+
+    def test_snippet_flags_unsupported_opcodes(self):
+        snippet, exact = triage.opcode_api_snippet(b"F1.0\n.")
+        self.assertFalse(exact)
+        self.assertIn("FLOAT", snippet)
+
+    def test_snippet_renders_global_via_factory(self):
+        data = Pickled([op.Proto.create(2), op.Global.create("os", "system"), op.Stop()]).dumps()
+        snippet, exact = triage.opcode_api_snippet(data)
+        self.assertTrue(exact, f"expected an exact rebuild, got:\n{snippet}")
+        self.assertIn("op.Global.create('os', 'system')", snippet)
+
+    def test_emit_writes_a_complete_artifact_set(self):
+        import tempfile
+
+        data = b"F1.0\n."
+        failure = scan.probe(data)
+        with tempfile.TemporaryDirectory() as tmp:
+            outdir = Path(tmp)
+            written = triage.emit(outdir, data, data, failure)
+            self.assertIsNotNone(written)
+            for name in ("original.pkl", "minimal.pkl", "repro.py", "report.md"):
+                self.assertTrue((written / name).exists(), f"missing {name}")
+            self.assertEqual((written / "minimal.pkl").read_bytes(), data)
+
+            report = (written / "report.md").read_text()
+            self.assertIn("NotImplementedError", report)
+            self.assertIn("Traceback", report)
+
+            # The emitted reproducer must scan, never load.
+            repro = (written / "repro.py").read_text()
+            self.assertIn("check_safety", repro)
+            self.assertNotIn("pickle.loads", repro)
+
+            # Second emit for the same signature is a no-op, so replaying a crash a
+            # thousand times does not churn the directory.
+            self.assertIsNone(triage.emit(outdir, data, data, failure))
+
+    def _run_emitted_repro(self, data: bytes):
+        """Emit a reproducer for `data`, run it in-process, and return what it raised."""
+        import tempfile
+
+        failure = scan.probe(data)
+        self.assertIsNotNone(failure, "expected this input to be a finding")
+        with tempfile.TemporaryDirectory() as tmp:
+            written = triage.emit(Path(tmp), data, data, failure)
+            source = (written / "repro.py").read_text()
+
+        namespace: dict = {"__name__": "repro_under_test"}
+        exec(compile(source, "repro.py", "exec"), namespace)
+        try:
+            namespace["main"]()
+        except BaseException as exc:  # noqa: BLE001 - whatever it raised is the result
+            return failure, exc, source
+        self.fail("the emitted reproducer exited cleanly instead of reproducing")
+
+    def test_repro_reproduces_a_scan_oracle_finding(self):
+        failure, raised, _ = self._run_emitted_repro(b"F1.0\n.")
+        self.assertEqual(failure.oracle, "scan")
+        self.assertIsInstance(raised, NotImplementedError)
+
+    def test_repro_reproduces_a_decompile_oracle_finding(self):
+        # The regression this guards: the template used to hardcode the scan path, so every
+        # decompiler finding shipped a reproducer that exited cleanly.
+        data = Pickled([op.Mark(), op.Dup(), op.Dict(), op.Dict(), op.Stop()]).dumps()
+        failure, raised, source = self._run_emitted_repro(data)
+        self.assertEqual(failure.oracle, "decompile")
+        self.assertIn("pickled.ast", source)
+        self.assertIsInstance(raised, ValueError)
+
+    def test_repro_drives_the_path_the_minimized_bytes_trip(self):
+        # emit() re-probes the minimized bytes, so the body matches reality even when the
+        # oracle differs from the one that originally reported it.
+        for data in (
+            b"F1.0\n.",
+            Pickled([op.Mark(), op.Dup(), op.Dict(), op.Dict(), op.Stop()]).dumps(),
+        ):
+            with self.subTest(data=data):
+                _, _, source = self._run_emitted_repro(data)
+                reprobed = scan.probe(data)
+                _, body = triage._REPRO_BODIES[reprobed.oracle]
+                self.assertIn(body.strip().splitlines()[0].strip(), source)
+
+    def test_hang_reproducer_asserts_on_slowness(self):
+        # A hang's oracle body completes, just slowly, so without a timing assertion the
+        # script exits 0 and reads as "does not reproduce".
+        source = triage.render_repro(BENIGN, "Timeout-scan", "scan", timeout_limit=2.0)
+        self.assertIn("import time", source)
+        self.assertIn("elapsed", source)
+        self.assertIn("2.0", source)
+
+    def test_non_hang_reproducer_has_no_timing_assertion(self):
+        source = triage.render_repro(BENIGN, "sig", "scan")
+        self.assertNotIn("elapsed", source)
+
+    def test_hang_reproducer_exits_nonzero_when_fast(self):
+        # A fast input under a hang reproducer must not silently pass as "reproduced".
+        source = triage.render_repro(BENIGN, "Timeout-scan", "scan", timeout_limit=2.0)
+        namespace: dict = {"__name__": "repro_under_test"}
+        exec(compile(source, "repro.py", "exec"), namespace)
+        with self.assertRaises(SystemExit):
+            namespace["main"]()
+
+    def test_every_oracle_has_a_reproducer_body(self):
+        # A new oracle without a body would raise KeyError at emit time, losing the finding.
+        for name, _fn in scan.ORACLES:
+            self.assertIn(name, triage._REPRO_BODIES)
+
+    def test_no_reproducer_body_deserializes(self):
+        for name, (imports, body) in triage._REPRO_BODIES.items():
+            with self.subTest(oracle=name):
+                source = imports + body
+                for forbidden in ("pickle.loads", "pickle.load", "Unpickler", "fickling.load"):
+                    self.assertNotIn(forbidden, source)
+
+    def test_disassembly_is_included_for_valid_pickles(self):
+        self.assertIn("PROTO", triage._disassemble(BENIGN))
+
+    def test_disassembly_degrades_on_truncated_input(self):
+        out = triage._disassemble(b"\x80\x04K")
+        self.assertIn("dis stopped", out)
+
+
+class TestKnownPickleShapes(unittest.TestCase):
+    """Sanity net: things the harness must classify correctly for real payloads."""
+
+    def test_dangerous_pickle_is_scanned_not_reported_as_a_bug(self):
+        # A malicious pickle is a high severity *result*, not a harness finding.
+        data = Pickled(
+            [
+                op.Proto.create(4),
+                op.ShortBinUnicode("os"),
+                op.ShortBinUnicode("system"),
+                op.StackGlobal(),
+                op.ShortBinUnicode("echo pwned"),
+                op.TupleOne(),
+                op.Reduce(),
+                op.Stop(),
+            ]
+        ).dumps()
+        self.assertIsNone(scan.probe(data))
+
+        from io import BytesIO
+
+        from fickling.analysis import Severity, check_safety
+
+        result = check_safety(Pickled.load(BytesIO(data)))
+        self.assertGreater(result.severity, Severity.LIKELY_SAFE)
+
+    def test_every_protocol_disassembles_and_scans(self):
+        import pickle as stdlib_pickle
+
+        for protocol in range(stdlib_pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(protocol=protocol):
+                data = stdlib_pickle.dumps([1, "two", {3: None}], protocol=protocol)
+                self.assertIsNone(scan.probe(data))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/fuzz/triage.py
+++ b/fuzz/triage.py
@@ -1,0 +1,308 @@
+"""Turn a crashing pickle into a minimal, filable reproducer.
+
+Minimization is delta debugging over the pickle: whole opcodes first, then individual
+bytes. A candidate is kept only if it reproduces the *same* signature, which matters
+because almost any truncation of a pickle produces *some* error.
+
+Emits per signature a directory with the original and minimized pickles, a standalone
+``repro.py``, and a report carrying the disassembly and an opcode-API skeleton for
+``test/test_bypasses.py``.
+"""
+
+from __future__ import annotations
+
+import pickletools
+import time
+from io import StringIO
+from pathlib import Path
+
+from fickling.fickle import OPCODES_BY_NAME
+from scan import DEFAULT_TIME_LIMIT, Failure, ScanTimeout, probe
+
+#: Byte-level ddmin is O(n^2)-ish in checks, so above this size the opcode pass alone has
+#: to do, rather than stalling the fuzzer.
+BYTE_PASS_MAX = 2048
+
+
+def _opcode_units(data: bytes) -> list[bytes] | None:
+    """Split `data` on opcode boundaries, or None if it is not disassemblable at all.
+
+    A partial disassembly is fine: the opcodes that did parse are still the right units.
+    """
+    starts: list[int] = []
+    try:
+        for _op, _arg, pos in pickletools.genops(data):
+            starts.append(pos)
+    except Exception:  # noqa: BLE001 - a partial disassembly is still useful
+        pass
+    if len(starts) < 2:
+        return None
+    # Each opcode runs from its own start to the next one; the last runs to end-of-input.
+    ends = [*starts[1:], len(data)]
+    return [data[a:b] for a, b in zip(starts, ends, strict=True)]
+
+
+def _ddmin(units: list[bytes], still_fails, budget) -> list[bytes]:
+    """Classic ddmin: shrink `units` while `still_fails(b"".join(units))` holds."""
+    n = 2
+    while len(units) >= 2:
+        size = max(1, len(units) // n)
+        chunks = [units[i : i + size] for i in range(0, len(units), size)]
+        for i in range(len(chunks)):
+            if not budget():
+                return units
+            candidate = [u for j, c in enumerate(chunks) if j != i for u in c]
+            if candidate and still_fails(b"".join(candidate)):
+                units = candidate
+                n = max(n - 1, 2)
+                break
+        else:
+            if n >= len(units):
+                break
+            n = min(n * 2, len(units))
+    return units
+
+
+def minimize(
+    data: bytes,
+    failure: Failure,
+    *,
+    max_checks: int = 1500,
+    time_budget: float = 5.0,
+) -> bytes:
+    """Shrink `data` while it keeps reproducing `failure`'s signature.
+
+    Bounded by check count and wall clock, returning the best candidate so far: this runs
+    inline in the fuzz loop, on top of libFuzzer's ``-max_total_time``.
+    """
+    deadline = time.monotonic() + time_budget
+    checks = 0
+
+    def budget() -> bool:
+        return checks < max_checks and time.monotonic() < deadline
+
+    def still_fails(candidate: bytes) -> bool:
+        nonlocal checks
+        checks += 1
+        found = probe(candidate)
+        return found is not None and found.signature == failure.signature
+
+    best = data
+    units = _opcode_units(best)
+    if units:
+        best = b"".join(_ddmin(units, still_fails, budget))
+
+    if len(best) <= BYTE_PASS_MAX and budget():
+        best = b"".join(_ddmin([best[i : i + 1] for i in range(len(best))], still_fails, budget))
+
+    return best
+
+
+# --- reproducer artifacts --------------------------------------------------------------
+
+#: Built through a factory rather than the plain constructor; `pickletools` decodes their
+#: argument as "module attr".
+_PAIR_FACTORIES = {"GLOBAL", "INST"}
+
+
+def opcode_api_snippet(data: bytes) -> tuple[str, bool]:
+    """Render `data` as fickling-opcode-API calls, plus whether that rendering was verified.
+
+    ``CLAUDE.md`` requires regression tests to build payloads through the opcode API, so
+    this does the transcription that would otherwise be done by hand. Verified by rebuilding
+    and comparing bytes, never presented as equivalent on faith.
+    """
+    lines: list[str] = []
+    rebuilt: list[object] = []
+    exact = True
+
+    try:
+        ops = list(pickletools.genops(data))
+    except Exception as exc:  # noqa: BLE001
+        return f"# not disassemblable: {type(exc).__name__}: {exc}", False
+
+    for op, arg, _pos in ops:
+        cls = OPCODES_BY_NAME.get(op.name)
+        if cls is None:
+            lines.append(f"    # no fickling Opcode class for {op.name} (arg={arg!r})")
+            exact = False
+            continue
+        if op.name == "PROTO":
+            lines.append(f"    op.Proto.create({arg!r}),")
+            rebuilt.append(cls.create(arg))
+        elif op.name in _PAIR_FACTORIES:
+            module, _, attr = str(arg).partition(" ")
+            lines.append(f"    op.{cls.__name__}.create({module!r}, {attr!r}),")
+            rebuilt.append(cls.create(module, attr))
+        elif arg is None:
+            lines.append(f"    op.{cls.__name__}(),")
+            rebuilt.append(cls())
+        else:
+            lines.append(f"    op.{cls.__name__}({arg!r}),")
+            rebuilt.append(cls(arg))
+
+    if exact:
+        try:
+            from fickling.fickle import Pickled
+
+            exact = Pickled(rebuilt).dumps() == data
+        except Exception:  # noqa: BLE001
+            exact = False
+
+    body = "\n".join(lines)
+    return f"pickled = Pickled(\n    [\n{body}\n    ]\n)", exact
+
+
+_REPRO_TEMPLATE = '''#!/usr/bin/env python3
+"""Standalone reproducer for {signature}.
+
+Exercises the {oracle} path. Scans only -- this never deserializes the pickle.
+Run:  python repro.py
+"""
+
+from io import BytesIO
+
+{imports}
+
+PICKLE = {payload}
+
+
+def main() -> None:
+{body}
+
+if __name__ == "__main__":
+    main()
+'''
+
+#: One body per oracle: the reproducer has to drive the *same* path the finding came from.
+#: A single fixed body would ship reproducers that exit cleanly for two of the three.
+_REPRO_BODIES = {
+    "scan": (
+        "from fickling.analysis import check_safety\nfrom fickling.fickle import StackedPickle",
+        "    for pickled in StackedPickle.load(BytesIO(PICKLE), fail_on_decode_error=True):\n"
+        "        check_safety(pickled)\n",
+    ),
+    "roundtrip": (
+        "from fickling.fickle import Pickled",
+        "    first = Pickled.load(BytesIO(PICKLE), fail_on_decode_error=True)\n"
+        "    once = first.dumps()\n"
+        "    twice = Pickled.load(BytesIO(once), fail_on_decode_error=True).dumps()\n"
+        "    if once != twice:\n"
+        '        raise AssertionError(f"dumps() not stable: {len(once)} -> {len(twice)}")\n',
+    ),
+    "decompile": (
+        "from fickling.fickle import Pickled",
+        "    pickled = Pickled.load(BytesIO(PICKLE), fail_on_decode_error=True)\n"
+        "    str(pickled.ast)\n",
+    ),
+}
+
+
+def render_repro(
+    payload: bytes, signature: str, oracle: str, timeout_limit: float | None = None
+) -> str:
+    """Render a standalone reproducer driving `oracle` over `payload`.
+
+    For a hang the body alone is not a reproducer -- it completes, just slowly, so the script
+    would exit 0. `timeout_limit` wraps it in a timing assertion so slowness is what fails.
+    """
+    imports, body = _REPRO_BODIES[oracle]
+    if timeout_limit is not None:
+        imports = f"import time\n\n{imports}"
+        body = (
+            f"    limit = {timeout_limit!r}\n"
+            "    started = time.monotonic()\n"
+            f"{body}"
+            "    elapsed = time.monotonic() - started\n"
+            "    if elapsed <= limit:\n"
+            '        raise SystemExit(f"completed in {elapsed:.2f}s, under the {limit}s limit")\n'
+            '    raise AssertionError(f"scanning took {elapsed:.2f}s (limit {limit}s)")\n'
+        )
+    return _REPRO_TEMPLATE.format(
+        signature=signature,
+        oracle=oracle,
+        imports=imports,
+        payload=repr(payload),
+        body=body,
+    )
+
+
+def _disassemble(data: bytes) -> str:
+    out = StringIO()
+    try:
+        pickletools.dis(data, out=out)
+    except Exception as exc:  # noqa: BLE001 - a truncated disassembly is still informative
+        return f"{out.getvalue()}\n<dis stopped: {type(exc).__name__}: {exc}>"
+    return out.getvalue()
+
+
+def emit(outdir: Path, original: bytes, minimal: bytes, failure: Failure) -> Path | None:
+    """Write the artifact set for `failure`. Returns the directory, or None if already known.
+
+    Deduplicates by signature so libFuzzer replaying a crash, or the same bug arriving from
+    a hundred different inputs, does not churn the directory.
+    """
+    target = outdir / failure.signature
+    if target.exists():
+        return None
+    target.mkdir(parents=True, exist_ok=True)
+
+    (target / "original.pkl").write_bytes(original)
+    (target / "minimal.pkl").write_bytes(minimal)
+
+    # Re-probe rather than trust the original oracle: signatures exclude the oracle, so a
+    # shrunken input can surface the same bug through an earlier path.
+    reprobed = probe(minimal)
+    oracle = reprobed.oracle if reprobed is not None else failure.oracle
+    is_hang = isinstance((reprobed or failure).exc, ScanTimeout)
+    (target / "repro.py").write_text(
+        render_repro(
+            minimal,
+            failure.signature,
+            oracle,
+            timeout_limit=DEFAULT_TIME_LIMIT if is_hang else None,
+        )
+    )
+
+    snippet, exact = opcode_api_snippet(minimal)
+    verified = (
+        "verified: rebuilding through these opcodes reproduces minimal.pkl byte-for-byte"
+        if exact
+        else "APPROXIMATE: does not rebuild minimal.pkl exactly; check before using"
+    )
+    (target / "report.md").write_text(
+        f"""# {failure.signature}
+
+    oracle:     {oracle}{"" if oracle == failure.oracle else f" (first seen via {failure.oracle})"}
+    exception:  {type(failure.exc).__name__}: {failure.exc}
+    original:   {len(original)} bytes
+    minimized:  {len(minimal)} bytes
+
+## Reproduce
+
+```
+python {target / "repro.py"}
+```
+
+## Traceback
+
+```
+{failure.traceback.rstrip()}
+```
+
+## Minimized pickle
+
+```
+{_disassemble(minimal).rstrip()}
+```
+
+## As a regression test
+
+`test/test_bypasses.py` builds payloads through the opcode API. Skeleton ({verified}):
+
+```python
+{snippet}
+```
+"""
+    )
+    return target

--- a/fuzz/uv.lock
+++ b/fuzz/uv.lock
@@ -1,0 +1,430 @@
+version = 1
+revision = 3
+requires-python = "==3.14.*"
+
+[[package]]
+name = "atheris"
+version = "3.1.0"
+source = { git = "https://github.com/google/atheris?rev=e36da74cf42b5834c4e31d7cabb58d796695d29f#e36da74cf42b5834c4e31d7cabb58d796695d29f" }
+
+[[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
+name = "brotlicffi"
+version = "1.2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b6/017dc5f852ed9b8735af77774509271acbf1de02d238377667145fcee01d/brotlicffi-1.2.0.1.tar.gz", hash = "sha256:c20d5c596278307ad06414a6d95a892377ea274a5c6b790c2548c009385d621c", size = 478156, upload-time = "2026-03-05T19:54:11.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/f9/dfa56316837fa798eac19358351e974de8e1e2ca9475af4cb90293cd6576/brotlicffi-1.2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c85e65913cf2b79c57a3fdd05b98d9731d9255dc0cb696b09376cc091b9cddd", size = 433046, upload-time = "2026-03-05T19:53:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f5/f8f492158c76b0d940388801f04f747028971ad5774287bded5f1e53f08d/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:535f2d05d0273408abc13fc0eebb467afac17b0ad85090c8913690d40207dac5", size = 1541126, upload-time = "2026-03-05T19:53:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e1/ff87af10ac419600c63e9287a0649c673673ae6b4f2bcf48e96cb2f89f60/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce17eb798ca59ecec67a9bb3fd7a4304e120d1cd02953ce522d959b9a84d58ac", size = 1541983, upload-time = "2026-03-05T19:53:50.317Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c0/80ecd9bd45776109fab14040e478bf63e456967c9ddee2353d8330ed8de1/brotlicffi-1.2.0.1-cp314-cp314t-win32.whl", hash = "sha256:3c9544f83cb715d95d7eab3af4adbbef8b2093ad6382288a83b3a25feb1a57ec", size = 349047, upload-time = "2026-03-05T19:53:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/98/13e5b250236a281b6cd9e92a01ee1ae231029fa78faee932ef3766e1cb24/brotlicffi-1.2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:625f8115d32ae9c0740d01ea51518437c3fbaa3e78d41cb18459f6f7ac326000", size = 385652, upload-time = "2026-03-05T19:53:53.892Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9f/b98dcd4af47994cee97aebac866996a006a2e5fc1fd1e2b82a8ad95cf09c/brotlicffi-1.2.0.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:91ba5f0ccc040f6ff8f7efaf839f797723d03ed46acb8ae9408f99ffd2572cf4", size = 432608, upload-time = "2026-03-05T19:53:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/7a/ac4ee56595a061e3718a6d1ea7e921f4df156894acffb28ed88a1fd52022/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9a670c6811af30a4bd42d7116dc5895d3b41beaa8ed8a89050447a0181f5ce", size = 1534257, upload-time = "2026-03-05T19:53:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/e7410db7f6f56de57744ea52a115084ceb2735f4d44973f349bb92136586/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3314a3476f59e5443f9f72a6dff16edc0c3463c9b318feaef04ae3e4683f5a", size = 1536838, upload-time = "2026-03-05T19:54:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/75/6e7977d1935fc3fbb201cbd619be8f2c7aea25d40a096967132854b34708/brotlicffi-1.2.0.1-cp38-abi3-win32.whl", hash = "sha256:82ea52e2b5d3145b6c406ebd3efb0d55db718b7ad996bd70c62cec0439de1187", size = 343337, upload-time = "2026-03-05T19:54:02.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ef/e7e485ce5e4ba3843a0a92feb767c7b6098fd6e65ce752918074d175ae71/brotlicffi-1.2.0.1-cp38-abi3-win_amd64.whl", hash = "sha256:da2e82a08e7778b8bc539d27ca03cdd684113e81394bfaaad8d0dfc6a17ddede", size = 379026, upload-time = "2026-03-05T19:54:04.322Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+]
+
+[[package]]
+name = "cisco-ai-defense-pickle-fuzzer"
+version = "1.0.1"
+source = { git = "https://github.com/cisco-ai-defense/pickle-fuzzer?rev=v1.0.1#25cacb1fdcbec8fb499186368f6dc06dead30934" }
+dependencies = [
+    { name = "atheris" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/5f/aed265fd7a3551a394f36dfe41868aee709b7f95db4052205b4ad1563ac3/coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a", size = 221650, upload-time = "2026-07-15T18:55:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/2c/222ba12a545189017120f8eddfc1a0bd4616b47d5d4a8d99421edb2fe4c6/coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2", size = 221988, upload-time = "2026-07-15T18:55:16.674Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/304b5877ab46e6c290b4292cfcf3fe28245f0e5597cad7f6acc91fc7e0a4/coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138", size = 253029, upload-time = "2026-07-15T18:55:18.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/821b533b8db9e44cf1d8a97bd525149ced40dde1d0093da02cb78e715244/coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f", size = 255536, upload-time = "2026-07-15T18:55:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f2/7aa06604c389d32ea7f0a6a988359a7eafc3cd3f8e7bc2e88cd2fdf0b877/coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984", size = 256881, upload-time = "2026-07-15T18:55:23.125Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4f/1ef342339c7916d0096bc5888cc0f653882cc7bc8f897d5cb89143287c9b/coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7", size = 259196, upload-time = "2026-07-15T18:55:25.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f4/7ed055d7a9c5ec13b161773a115a5ccc6b0081d568c31fad830806306cc7/coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3", size = 253036, upload-time = "2026-07-15T18:55:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/14/79/ea82cca18c242a3a38b6c017da39726aa62dcb64aa635abf79b92009975c/coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee", size = 254887, upload-time = "2026-07-15T18:55:29.084Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ba/a136db3c0d9562b00e10b72540dbf3a33cd3bc5b95060c9308e247494623/coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1", size = 252852, upload-time = "2026-07-15T18:55:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/17/17/ea334246b16b7d059953fad6fdefa11e33c68efbd3fe37b1098120a1fac2/coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a", size = 257128, upload-time = "2026-07-15T18:55:33.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c3/074fb66d46d607855f710876b117cbda562c5ab08363528e78820449f937/coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145", size = 252668, upload-time = "2026-07-15T18:55:35.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c1/f620850ada9b36435921c9a3a8057013422b1d964eb4bf37fe138724d192/coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446", size = 254325, upload-time = "2026-07-15T18:55:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/31/a729ca3689404493af82ef8e6ff70bd88bdda8da89aeef6ca9b387aeb2b4/coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243", size = 223844, upload-time = "2026-07-15T18:55:39.078Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/83/5d809dc808fb1698c671f3e372259bb9158e64b7ea526fc6ab7de64de9fe/coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc", size = 224331, upload-time = "2026-07-15T18:55:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/35e488548e952795829e129995c4174df33bf432b591d1aa42c8d9e4e7ad/coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635", size = 223760, upload-time = "2026-07-15T18:55:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/49/dd2c86cd6374038f6e415fb5bfb86db5218553209c081384a020369dee79/coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be", size = 222384, upload-time = "2026-07-15T18:55:45.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/173ff17a1c0808e5a438f549f6f145d5ac7528f2791310b63523e3200ac7/coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072", size = 222647, upload-time = "2026-07-15T18:55:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f8/b8cba872162356fb44ac79c10309d987206a4461e32072fc29228dad7331/coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328", size = 264013, upload-time = "2026-07-15T18:55:49.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/67/a807a7586d0b8cae485308ddd55756f0806c92f8e0b411bacbf23c48edf3/coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a", size = 266135, upload-time = "2026-07-15T18:55:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/cd78771dc985f7e4ebdcc82b1a96d9a932af9e806f01f2f91a89f4c72e80/coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0", size = 268555, upload-time = "2026-07-15T18:55:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3e/10134cf81275188c58568f324fc74aedff32c63ca4d5bbc513a91944a6f0/coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5", size = 269674, upload-time = "2026-07-15T18:55:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/771b77de446cba985dc414bbc5844bd21604da05dbc044286df8318a48a7/coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743", size = 263101, upload-time = "2026-07-15T18:55:58.107Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b5/70a7011da15f4071943361183aefa27847f3e3aec4fd335f1cb3d3a622b1/coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c", size = 266007, upload-time = "2026-07-15T18:56:00.468Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/f9547e804ce7ad49646ffeffac26699510efbe6c0f751b66fdc960c4e825/coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071", size = 263611, upload-time = "2026-07-15T18:56:02.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/59/f576a396659c0efd351f5c1544f67c3560e89c7761cabf7f65e412beeda5/coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a", size = 267344, upload-time = "2026-07-15T18:56:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5d/c2e4fce3579c0cb635024293f1a32bbe26df101b3e3a69f22243d1352b6c/coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d", size = 262456, upload-time = "2026-07-15T18:56:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/956287d69436b66094bc4b57ac2da71e43bfd2a5524e958900b9f582fcf8/coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c", size = 264771, upload-time = "2026-07-15T18:56:08.795Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5a/6f979530c2734c575de77cf58f5f28d51f7123a94b5030fd9156fe5f363c/coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688", size = 224151, upload-time = "2026-07-15T18:56:10.856Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7e/27f6b2a74d484742f4017553e710b01e396b23d809df3e95ca0bb9a2824b/coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199", size = 224981, upload-time = "2026-07-15T18:56:12.928Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/48/284863423aa474240f6842bd00d680da22f4e6ea2e466618ef7c9c9e69a9/coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658", size = 224294, upload-time = "2026-07-15T18:56:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
+]
+
+[[package]]
+name = "fickling"
+source = { editable = "../" }
+
+[package.optional-dependencies]
+archive = [
+    { name = "py7zr" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7.0.0" },
+    { name = "huggingface-hub", marker = "extra == 'dev'", specifier = ">=0.20.0" },
+    { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.20.0" },
+    { name = "numpy", marker = "python_full_version == '3.10.*' and extra == 'dev'", specifier = ">=2.2.6,<2.3" },
+    { name = "numpy", marker = "python_full_version == '3.10.*' and extra == 'huggingface'", specifier = ">=2.2.6,<2.3" },
+    { name = "numpy", marker = "python_full_version == '3.10.*' and extra == 'test'", specifier = ">=2.2.6,<2.3" },
+    { name = "numpy", marker = "python_full_version == '3.10.*' and extra == 'torch'", specifier = ">=2.2.6,<2.3" },
+    { name = "numpy", marker = "python_full_version >= '3.11' and extra == 'dev'", specifier = ">=2.3.5" },
+    { name = "numpy", marker = "python_full_version >= '3.11' and extra == 'huggingface'", specifier = ">=2.3.5" },
+    { name = "numpy", marker = "python_full_version >= '3.11' and extra == 'test'", specifier = ">=2.3.5" },
+    { name = "numpy", marker = "python_full_version >= '3.11' and extra == 'torch'", specifier = ">=2.3.5" },
+    { name = "numpy", marker = "extra == 'examples'" },
+    { name = "py7zr", marker = "extra == 'archive'", specifier = ">=1.1.0,!=1.1.2" },
+    { name = "py7zr", marker = "extra == 'dev'", specifier = ">=1.1.0,!=1.1.2" },
+    { name = "py7zr", marker = "extra == 'test'", specifier = ">=1.1.0,!=1.1.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5.0.0" },
+    { name = "pytorchfi", marker = "extra == 'examples'" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.8.0" },
+    { name = "torch", marker = "extra == 'dev'", specifier = ">=2.1.0" },
+    { name = "torch", marker = "extra == 'huggingface'", specifier = ">=2.1.0" },
+    { name = "torch", marker = "extra == 'test'", specifier = ">=2.1.0" },
+    { name = "torch", marker = "extra == 'torch'", specifier = ">=2.1.0" },
+    { name = "torchvision", marker = "extra == 'dev'", specifier = ">=0.24.1" },
+    { name = "torchvision", marker = "extra == 'huggingface'", specifier = ">=0.24.1" },
+    { name = "torchvision", marker = "extra == 'test'", specifier = ">=0.24.1" },
+    { name = "torchvision", marker = "extra == 'torch'", specifier = ">=0.24.1" },
+    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.12" },
+    { name = "ty", marker = "extra == 'lint'", specifier = ">=0.0.12" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' and extra == 'dev'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' and extra == 'lint'" },
+]
+provides-extras = ["archive", "dev", "examples", "huggingface", "lint", "test", "torch"]
+
+[[package]]
+name = "fickling-fuzz"
+version = "0"
+source = { virtual = "." }
+dependencies = [
+    { name = "atheris" },
+    { name = "cisco-ai-defense-pickle-fuzzer" },
+    { name = "coverage" },
+    { name = "fickling", extra = ["archive"] },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "atheris", git = "https://github.com/google/atheris?rev=e36da74cf42b5834c4e31d7cabb58d796695d29f" },
+    { name = "cisco-ai-defense-pickle-fuzzer", git = "https://github.com/cisco-ai-defense/pickle-fuzzer?rev=v1.0.1" },
+    { name = "coverage", extras = ["toml"], specifier = ">=7.0.0" },
+    { name = "fickling", extras = ["archive"], editable = "../" },
+    { name = "pytest", specifier = ">=8.0.0" },
+]
+
+[[package]]
+name = "inflate64"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/f3/41bb2901543abe7aad0b0b0284ae5854bb75f848cf406bf8a046bf525f67/inflate64-1.0.4.tar.gz", hash = "sha256:b398c686960c029777afc0ed281a86f66adb956cfc3fbf6667cc6453f7b407ce", size = 902542, upload-time = "2025-11-28T10:55:52.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/fb/ec9d10f44f2fc7666ad5d70acae2b8a1941e8e08ccae1fad0820f7796be3/inflate64-1.0.4-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4f61925b2d4248eac2ebb15350a80aaa0d1f7f1dc770bd5ebbbb3b0db4a6a416", size = 58727, upload-time = "2025-11-28T10:55:13.834Z" },
+    { url = "https://files.pythonhosted.org/packages/81/80/24ba0d2ee14e07e275e9c5b058e59a8a58f8ef42dd51a78ebbfd7c857ac4/inflate64-1.0.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c1acf18b08b32981a4a11ec5a112b8ad5d7c7a5b15cb5bdbdb5b19201e9aa180", size = 35945, upload-time = "2025-11-28T10:55:15.225Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b8/073a79716e093db973b8823bdfb02e10fbdf65642dbe1fa3cda24832aeb2/inflate64-1.0.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:abddae8920b2eaef824254e14b8d4ff54afbe6194a1bbe9816584859f0c1244d", size = 36060, upload-time = "2025-11-28T10:55:16.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f0/87d3c317ed0acd94f5e9b3b1b9e9000228ea2af0cb4618c62cbfc816da34/inflate64-1.0.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b303132cc562a906543a56f35c4e164e3880da6ff041cb4a7b1df9f9d2b4bb69", size = 98995, upload-time = "2025-11-28T10:55:17.405Z" },
+    { url = "https://files.pythonhosted.org/packages/90/72/0b6035302e9c33f004240a50cb6e2e1fc7bb1f2b415b02d939c551bdd06b/inflate64-1.0.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f0993214dea0738c557fa56c13cd9083aef0097a201d726c21984ad7f577514", size = 100781, upload-time = "2025-11-28T10:55:18.597Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/05/5f383c615ec0f01bcbbc699a71da167623e494083ab7ed0df86b4bddf125/inflate64-1.0.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a6baedc3288d7a4ff588951d3a9a97a5391dceed6255ff5b16e42cae7274bfa9", size = 97038, upload-time = "2025-11-28T10:55:20.156Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9a/c1482718c717c49c67490c42b4fdced9476e894eaebd52193e488c12e188/inflate64-1.0.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a846ce1f38845b20bef2625af1b512be83416d97824539524c5a34e7a729aec7", size = 100016, upload-time = "2025-11-28T10:55:21.337Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7f/700ede7474e72a1c0e2e8fe36624cd0225ca8b2875eca33d64aa2de75f4d/inflate64-1.0.4-cp314-cp314-win32.whl", hash = "sha256:eef87908c780439393d577a155868317f0a275b47b417db9f47d8633ec791745", size = 33691, upload-time = "2025-11-28T10:55:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/f2972df8cceecc9bf3afa3353d517ffc7125285198c844588e9aaf98f5d0/inflate64-1.0.4-cp314-cp314-win_amd64.whl", hash = "sha256:fb2fdd63ef3933b67af98b3f2ee2f57e7787278041d7ba4821382fedd729b68a", size = 36304, upload-time = "2025-11-28T10:55:24.005Z" },
+    { url = "https://files.pythonhosted.org/packages/29/77/16200aced67215119fb30ec9a5889b48289ee2fa5ce5137623a9ad41b2c4/inflate64-1.0.4-cp314-cp314-win_arm64.whl", hash = "sha256:2e129669a0243ac7816fd526946ee01c25688fe81623a6d6bc95b3156d80f4fb", size = 34491, upload-time = "2025-11-28T10:55:25.068Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/79/b466ec7666c40912ea81a305a8a2b75f5998e6cec1d3d75e067d76203731/inflate64-1.0.4-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b17bf665d948dc4edeea0cd17752415d0cd7240c882b9c7e136ad4cc4321e9d4", size = 59300, upload-time = "2025-11-28T10:55:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ad/16e1168ac80f39894e6cb18b439eec63fec42cbced239aebfe12081b6ec7/inflate64-1.0.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6751758301936fbb38fa38eb5312e14e27b6a1abf568f83c17557fab2694373d", size = 36258, upload-time = "2025-11-28T10:55:27.295Z" },
+    { url = "https://files.pythonhosted.org/packages/25/42/c463b42fd8a7947b4445fbaf57c265bb7f3114362fb7aee6884ffd8b5341/inflate64-1.0.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d6a4136752aa2a544301059d8f13780aeb88c34d60770258436a87dacd3fc304", size = 36296, upload-time = "2025-11-28T10:55:28.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/f1/cf6121926e405020e9e7bccb78ec7781fbc87500ec67368e7d9e866758be/inflate64-1.0.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:938ebc6b28578bfd365d1a9fdb18b7faab08321babeb2198e8025d07d8dc7fb5", size = 106788, upload-time = "2025-11-28T10:55:29.797Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/dd/b653f9962497cf4d3520d69272894c37fd76f86a0e04bb3bd9f32827dc2f/inflate64-1.0.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61f51f80fa6f367288343c1a2cd20a42af454883087064e9274fd2a8c3a5a200", size = 107959, upload-time = "2025-11-28T10:55:31.306Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ae/65d88109b63611c9b6c29008201107127cf2603d186ab99beec39d85f38e/inflate64-1.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:172b51da7bbfa66b33f0a5405e944807b9949e92cf4cd9f983c07af8152766df", size = 104213, upload-time = "2025-11-28T10:55:32.506Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/94/c17de2f55b9fb1269bca4657f9089efe4ba0f3d4b652f07b34dfc69f69a2/inflate64-1.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8ca9a2985afd5a14fb48cd126a67e5944ccb7a0a6bdec58c4f796c8c88a84539", size = 106629, upload-time = "2025-11-28T10:55:33.735Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/30/8bbc587bb2ad09ab7edf1f9215b2c5faf4fa7ee7c071daefe9ed55e28814/inflate64-1.0.4-cp314-cp314t-win32.whl", hash = "sha256:f8964ceaabea294bc20abc9ef408c6aae978a75c25c83168a76cd87a37c38938", size = 33865, upload-time = "2025-11-28T10:55:35.335Z" },
+    { url = "https://files.pythonhosted.org/packages/91/87/8bf6f412f93c8b6dc14866a021b83321331fbdd17f6ab902a24dbf88773d/inflate64-1.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:7d13b04cba65c12d21e65eaa77da9484e265e8e821b26e0761d1455ad3a878d9", size = 36943, upload-time = "2025-11-28T10:55:36.983Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/85/33447bb3c4e3c0ae7b1fde3aadc52a18b2b0193cfcf4f585977e924c6463/inflate64-1.0.4-cp314-cp314t-win_arm64.whl", hash = "sha256:9ae3ee727235a06dc3cd353ee5761fdd8e3b56ad119c711f61680528972a6ced", size = 34846, upload-time = "2025-11-28T10:55:38.433Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "multivolumefile"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/f0/a7786212b5a4cb9ba05ae84a2bbd11d1d0279523aea0424b6d981d652a14/multivolumefile-0.2.3.tar.gz", hash = "sha256:a0648d0aafbc96e59198d5c17e9acad7eb531abea51035d08ce8060dcad709d6", size = 77984, upload-time = "2021-04-29T12:18:39.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/31/ec5f46fd4c83185b806aa9c736e228cb780f13990a9cf4da0beb70025fcc/multivolumefile-0.2.3-py3-none-any.whl", hash = "sha256:237f4353b60af1703087cf7725755a1f6fcaeeea48421e1896940cd1c920d678", size = 17037, upload-time = "2021-04-29T12:18:38.886Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "py7zr"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
+    { name = "brotlicffi", marker = "platform_python_implementation == 'PyPy'" },
+    { name = "inflate64" },
+    { name = "multivolumefile" },
+    { name = "psutil", marker = "sys_platform != 'cygwin'" },
+    { name = "pybcj" },
+    { name = "pycryptodomex" },
+    { name = "pyppmd" },
+    { name = "texttable" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/3f/ac248f25f3901d3d6cf80ac99d5bac6fd1e5e6543c1812c79b02b6074c60/py7zr-1.1.3.tar.gz", hash = "sha256:8d51894abb38355bf14881088bb97f01fe4cb5b14ebe22f66d6297668c7e1a74", size = 71695, upload-time = "2026-06-19T09:28:29.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/40/dc7f804abd0ea167ea8d4d9b3f5455321aaf671d040fcef647e9e952e714/py7zr-1.1.3-py3-none-any.whl", hash = "sha256:17934a35089e026dec6c72ee275d9b841e646881ef822d618e805c3006661d9a", size = 72242, upload-time = "2026-06-19T09:28:27.512Z" },
+]
+
+[[package]]
+name = "pybcj"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/c9/e2de4f98c21f2ff9e58047395b6a8e17701a0f2977f0e63f80948f61647f/pybcj-1.0.8.tar.gz", hash = "sha256:6818270692912d47e81ccd777b7d0ed2ad3a19ef7aaead3735b38048c80bf368", size = 31763, upload-time = "2026-07-16T22:47:24.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/9a/6ae6062f0a7707a6c818f69653af34be90dffec0450c6a39790a1a7d918e/pybcj-1.0.8-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b8d80571db5f89944aced42378b208afe38339008027ec56303e11628615a906", size = 33353, upload-time = "2026-07-16T22:47:02.452Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7d/182735114b34301326ad197daae729e1b2a67c2be8e4ee661acabb1c4e04/pybcj-1.0.8-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:07eac7a1a8804230060fe56a5d828c620ee2d70acd31aef80705a01627da5946", size = 24737, upload-time = "2026-07-16T22:47:03.754Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/0a/0d97486364bdf079631fc9b72b9cad42579fe2f0ce575fc67208037ce041/pybcj-1.0.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:af962c96a799ee7b13b9747a73240ba7f73e8643c276492f10e1dc60b564b295", size = 24980, upload-time = "2026-07-16T22:47:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/28/f50bbf5c154f6eebca31789228b547e135fe541d46c85a026cadb842e8f2/pybcj-1.0.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:067982ad967ce68ae28c13cc27f96d8b65b5f497819dd4ad5c4f05ffc2fb2ae3", size = 53385, upload-time = "2026-07-16T22:47:06.039Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/4f/9f226e64cf82b59d9f803e59f32496edfcd52a40305378eb1dd1f78bb18d/pybcj-1.0.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f23a36e978f4620db473b08239ab56dc57a479c83fd5d3808bc95e5bdbc1a703", size = 52372, upload-time = "2026-07-16T22:47:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d7/b52cbdaee0e41fd44edcf032dbcfe5bce7a4b0a8f9fe3fb38ec402fe99a7/pybcj-1.0.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ba3b8f1efd1ebbe3ee99a599c6ea745877a41675a0ade763903b644ccd58da97", size = 51326, upload-time = "2026-07-16T22:47:08.53Z" },
+    { url = "https://files.pythonhosted.org/packages/52/16/cafe2644f876639ae85c0a6fbe262c11f8065dd4b806eb4f6ace190076a3/pybcj-1.0.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:09c3fe78d325a499fdd0a003b04b0009a3921666dc590d1b7a496dc365eef3a9", size = 50874, upload-time = "2026-07-16T22:47:09.752Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c4/767af5f90007cf5b138b2b4b40cf34998ca143fb22210c9d718d04eb2b22/pybcj-1.0.8-cp314-cp314-win_amd64.whl", hash = "sha256:0074af187b1acce9e31717fc9aa42bc36b67f1a44088a8b44f4f4792af688ee6", size = 25225, upload-time = "2026-07-16T22:47:11.144Z" },
+    { url = "https://files.pythonhosted.org/packages/22/30/bdbe671d8156ef0f3d8a5ac4d0bccc98bf1d573e1bb10ff6225383211351/pybcj-1.0.8-cp314-cp314-win_arm64.whl", hash = "sha256:458a5bff57f36fba7af822df64da335fa1781d592dd7f802f347ae1f75939aa0", size = 24460, upload-time = "2026-07-16T22:47:12.479Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/13/45ec85efc37d71b3def7ad755d9ab964c1a00e9ebc02fd1cd6b199f2535f/pybcj-1.0.8-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:083b41b59672d4aa893b44769bed7a41abfde43211b27d47a0d4d66a59fdafad", size = 33916, upload-time = "2026-07-16T22:47:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c8/0988ce2bd104c24285a967e2dbddf9c07e0055354fae6a9ccace4202ef66/pybcj-1.0.8-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d432a32bfc23475b7fd62a5eb1c3243a8329ff95aa0e3c941d57902dc6e7c87", size = 25026, upload-time = "2026-07-16T22:47:14.777Z" },
+    { url = "https://files.pythonhosted.org/packages/86/37/ba7823ed5831d656eb7e841e026492d8540b59235210b68ba885c8bd0219/pybcj-1.0.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cb1601253a15abfaba42e0bdbde4d459d2afcafdc97dee0d9b698e589167fd8d", size = 25268, upload-time = "2026-07-16T22:47:15.909Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1e/572c7e32da9bca384aa28401c09c153eb5bf1b0c64e249e9f13fbbdfadae/pybcj-1.0.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78498748ebea7e1483f9cfdeac4a08687f6e2773e3a4223c420ab1beae95d75d", size = 59685, upload-time = "2026-07-16T22:47:17.227Z" },
+    { url = "https://files.pythonhosted.org/packages/67/09/737dcd04aa137c91e33b89b8d68b763419c39feff14c9cf5eeb945954a6b/pybcj-1.0.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3817997e73d60ccbc731a47e007fe02213eee816cfe6070eb8347c6286aa3cc2", size = 57872, upload-time = "2026-07-16T22:47:18.476Z" },
+    { url = "https://files.pythonhosted.org/packages/53/31/519a41bf9ea3c58368bd72e6bd3a2eaf735aef206e715e87e2d0c4f5bb6f/pybcj-1.0.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2a9146d8f3df70305dba6cb9c3d25f285a9a69309e4941333962f5408a244be", size = 56908, upload-time = "2026-07-16T22:47:19.85Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6a/fdc7b48e1b27f5cd44f554ca730e1928074d51db5bc640ec92323c46a689/pybcj-1.0.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5824e498e2dfafc19a2de2bdf54e5c2857144d84983ac8e13e54b1f7b78e3f50", size = 56063, upload-time = "2026-07-16T22:47:21.1Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c2/3d3d99065816de8acafc77917ac4c0b8e8df74f407ec2955a26f8b641a67/pybcj-1.0.8-cp314-cp314t-win_amd64.whl", hash = "sha256:331c21f0636150d4b846e0749cb0e8d6cbd133692368b391f9ba75dc02d5c51f", size = 25481, upload-time = "2026-07-16T22:47:22.357Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/0901ba3b67842dbf4263c832ab8b05d6441eabfd97bec1d77d27b90a7a4c/pybcj-1.0.8-cp314-cp314t-win_arm64.whl", hash = "sha256:935e0588be20a2b7c3554a6415d1fdb66acfde037df718b7927033b658428518", size = 24893, upload-time = "2026-07-16T22:47:23.547Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pycryptodomex"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/85/e24bf90972a30b0fcd16c73009add1d7d7cd9140c2498a68252028899e41/pycryptodomex-3.23.0.tar.gz", hash = "sha256:71909758f010c82bc99b0abf4ea12012c98962fbf0583c2164f8b84533c2e4da", size = 4922157, upload-time = "2025-05-17T17:23:41.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/9c/1a8f35daa39784ed8adf93a694e7e5dc15c23c741bbda06e1d45f8979e9e/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:06698f957fe1ab229a99ba2defeeae1c09af185baa909a31a5d1f9d42b1aaed6", size = 2499240, upload-time = "2025-05-17T17:22:46.953Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/62/f5221a191a97157d240cf6643747558759126c76ee92f29a3f4aee3197a5/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2c2537863eccef2d41061e82a881dcabb04944c5c06c5aa7110b577cc487545", size = 1644042, upload-time = "2025-05-17T17:22:49.098Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/fd/5a054543c8988d4ed7b612721d7e78a4b9bf36bc3c5ad45ef45c22d0060e/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43c446e2ba8df8889e0e16f02211c25b4934898384c1ec1ec04d7889c0333587", size = 2186227, upload-time = "2025-05-17T17:22:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a9/8862616a85cf450d2822dbd4fff1fcaba90877907a6ff5bc2672cafe42f8/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f489c4765093fb60e2edafdf223397bc716491b2b69fe74367b70d6999257a5c", size = 2272578, upload-time = "2025-05-17T17:22:53.676Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/bda9c49a7c1842820de674ab36c79f4fbeeee03f8ff0e4f3546c3889076b/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdc69d0d3d989a1029df0eed67cc5e8e5d968f3724f4519bd03e0ec68df7543c", size = 2312166, upload-time = "2025-05-17T17:22:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/03/cc/870b9bf8ca92866ca0186534801cf8d20554ad2a76ca959538041b7a7cf4/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6bbcb1dd0f646484939e142462d9e532482bc74475cecf9c4903d4e1cd21f003", size = 2185467, upload-time = "2025-05-17T17:22:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e3/ce9348236d8e669fea5dd82a90e86be48b9c341210f44e25443162aba187/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:8a4fcd42ccb04c31268d1efeecfccfd1249612b4de6374205376b8f280321744", size = 2346104, upload-time = "2025-05-17T17:23:02.112Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e869bcee87beb89040263c416a8a50204f7f7a83ac11897646c9e71e0daf/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55ccbe27f049743a4caf4f4221b166560d3438d0b1e5ab929e07ae1702a4d6fd", size = 2271038, upload-time = "2025-05-17T17:23:04.872Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/67/09ee8500dd22614af5fbaa51a4aee6e342b5fa8aecf0a6cb9cbf52fa6d45/pycryptodomex-3.23.0-cp37-abi3-win32.whl", hash = "sha256:189afbc87f0b9f158386bf051f720e20fa6145975f1e76369303d0f31d1a8d7c", size = 1771969, upload-time = "2025-05-17T17:23:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/69/96/11f36f71a865dd6df03716d33bd07a67e9d20f6b8d39820470b766af323c/pycryptodomex-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:52e5ca58c3a0b0bd5e100a9fbc8015059b05cffc6c66ce9d98b4b45e023443b9", size = 1803124, upload-time = "2025-05-17T17:23:09.267Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/93/45c1cdcbeb182ccd2e144c693eaa097763b08b38cded279f0053ed53c553/pycryptodomex-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:02d87b80778c171445d67e23d1caef279bf4b25c3597050ccd2e13970b57fd51", size = 1707161, upload-time = "2025-05-17T17:23:11.414Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyppmd"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/d7/803232913cab9163a1a97ecf2236cd7135903c46ac8d49613448d88e8759/pyppmd-1.3.1.tar.gz", hash = "sha256:ced527f08ade4408c1bfc5264e9f97ffac8d221c9d13eca4f35ec1ec0c7b6b2e", size = 1351815, upload-time = "2025-11-27T22:08:44.175Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/10/ac2a011af1c7c40b6482e60d85d267ac5923fb8794b51bfddbb56b04d1ec/pyppmd-1.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ea53f71ac16e113599b8441a9d8b6dcd71cfdf15cdb33ba5151810b8e656c5ec", size = 77897, upload-time = "2025-11-27T22:08:17.104Z" },
+    { url = "https://files.pythonhosted.org/packages/20/13/737f4dac06685865d23f51b7061dbe9373c7bcc60b5b6456cd08301bc807/pyppmd-1.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:985c8703b53e5f68fe17f653e96748d60b1f855676c852a6e67cd472eb853671", size = 48268, upload-time = "2025-11-27T22:08:18.263Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d3/c50ebaee8b8a064fe9a534e98df5051e309efb705728aadff4e6893cd87f/pyppmd-1.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:33daa996ad5203c665c0b55aff6329817b2cb7fa95f2c33a2e83ed0121b400cb", size = 48521, upload-time = "2025-11-27T22:08:19.742Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6c/4a97c0a0ab7640aeddde4843cb6381b80ecb71fe2c6c48b9032d60586b11/pyppmd-1.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b49870c6d7194f6eb80f30335ca03596d153e02fcde2c222e4f1202ac25f7fcf", size = 142892, upload-time = "2025-11-27T22:08:20.972Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/22/744c32c7da3de171d9e62a1b2cb4104544ac778358565a3dbc06a2253324/pyppmd-1.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:385e92c97c42e8a6f0bfc0e4acfc6c074cb1ba3a2f650f292696dd9f19e2e603", size = 144550, upload-time = "2025-11-27T22:08:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/18/84af6808e0754923062122d3ee9f0532050f1612069d558bb5d53978e67a/pyppmd-1.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:017a1e2903f1c3147a1046db486990d401e8a25eb52c320b1fc2fb3e7b83cbeb", size = 139850, upload-time = "2025-11-27T22:08:23.863Z" },
+    { url = "https://files.pythonhosted.org/packages/20/5e/dc6166ea7929d442625301289d99313a5b358e3cb2e927a6bd913047e8ee/pyppmd-1.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f2770a4b777c0c5236b3d9294b7bf4bc15538c95d45b2079eb8ebc1298e62e37", size = 142589, upload-time = "2025-11-27T22:08:25.228Z" },
+    { url = "https://files.pythonhosted.org/packages/77/92/adc6b12ddf11173a02fd631010f88ad4fe4c532363959638d5d53583a3d9/pyppmd-1.3.1-cp314-cp314-win32.whl", hash = "sha256:b9d54cd59ce97f2ba57be1da91b3d874d129faca21c9565d7afec111f942e6a1", size = 42761, upload-time = "2025-11-27T22:08:26.917Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4c/5003a413d9f2743298a070df6713a75dedccc470e7adeeced5b43cad7418/pyppmd-1.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0e64247618cb150d2909beb0137da3084fef1d3479b4cc73b5b47fda7611abf9", size = 47806, upload-time = "2025-11-27T22:08:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b7/db927e1df7fc3132cb57960f4ea23bf174c7e86ccec22857e6a35cccdae7/pyppmd-1.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:d354d6e551d2630b0ac98f27e3ad63e86cdcac9ce2115b5dfe46e2c9d3f4e82c", size = 46122, upload-time = "2025-11-27T22:08:29.191Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/5f/3150227624f374b06e331a7f67ae3383e796dd90973ee17ec3e35d30524c/pyppmd-1.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2d77ed79662c32e2551748d59763cfe3dcd10855bf3495937e3d5e5917507818", size = 78876, upload-time = "2025-11-27T22:08:30.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/11a3bba62d1d92050f4dd86db810062b506ec76d20b6e00b4ab567ff15e4/pyppmd-1.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6a1f92b94635c23d85270bb26db25cc0db544e436af86efc1cf58302d71d5af1", size = 48830, upload-time = "2025-11-27T22:08:32.087Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/e8f50cf89c689543d5a16c7be3df3c4afd43cbeb1a019b84ff9e82f13415/pyppmd-1.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:610f214f2405e27eb5a3dad7fa15f385cfc42141a01cda71995d9c1e0b09fab9", size = 48956, upload-time = "2025-11-27T22:08:33.567Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0f/944b30679a8dea3ea95a66531ee30cb6feb5d011ec7fd6832069d9130bf3/pyppmd-1.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae81a14895498d9a23429d92114c98da478b74b8e33251527d7cff3e01c09de0", size = 152872, upload-time = "2025-11-27T22:08:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/87/1e48ea92994f4c72dc9b5520a6a386b21c524d3d2969c2c2a5c325929ad7/pyppmd-1.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d1683e6d1ba09e377e0ae02de3a518191a3d63ccdb0b6037c74e6ddf577b5644", size = 154210, upload-time = "2025-11-27T22:08:36.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/21/650911f98c4cb360442724bbdade27cb3679b0587ea77e73512693d2918d/pyppmd-1.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e4d74fa0f3531e9dadc56e0ace41bce82d3c0babed47b3f224101dc0dbde7287", size = 147636, upload-time = "2025-11-27T22:08:37.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/4f8cfc1dd67b04ced8c10669fa14c4e35a42cf4a84e1101793735a82d5f0/pyppmd-1.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f8d6375b18b9c79127fee0885cfd52e2e983edb67041464309426571d38dcd4", size = 150998, upload-time = "2025-11-27T22:08:38.951Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/da/dc9e5e10bc56056bd8c33e533517cb327752cbaf172688bba3c23f6b2318/pyppmd-1.3.1-cp314-cp314t-win32.whl", hash = "sha256:de87f7acd575fb07a4ff42d41bcc071570fe759a36f345f1f54f574ecfccfc5b", size = 43016, upload-time = "2025-11-27T22:08:40.234Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a0/46dc15549ad2c0427a9825730e6bdf342045ad410543368afd4389a16f36/pyppmd-1.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:76e4800aa67292b4cc80058fd29b39e02a5dded721af9fe5654f356ef24307f4", size = 48636, upload-time = "2025-11-27T22:08:41.45Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/7b/7e9a83848de928c26f0ab3ee105c0da63a932a0804a94807205e6313e73a/pyppmd-1.3.1-cp314-cp314t-win_arm64.whl", hash = "sha256:e066cbf1d335fe20480cd8ecc10848ba78d99fe6d1e44ea00def48feaf46afdf", size = 46402, upload-time = "2025-11-27T22:08:42.804Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "texttable"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/dc/0aff23d6036a4d3bf4f1d8c8204c5c79c4437e25e0ae94ffe4bbb55ee3c2/texttable-1.7.0.tar.gz", hash = "sha256:2d2068fb55115807d3ac77a4ca68fa48803e84ebb0ee2340f858107a36522638", size = 12831, upload-time = "2023-10-03T09:48:12.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/99/4772b8e00a136f3e01236de33b0efda31ee7077203ba5967fcc76da94d65/texttable-1.7.0-py2.py3-none-any.whl", hash = "sha256:72227d592c82b3d7f672731ae73e4d1f88cd8e2ef5b075a7a7f01a23a3743917", size = 10768, upload-time = "2023-10-03T09:48:10.434Z" },
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,11 @@ Source = "https://github.com/trailofbits/fickling"
 
 # Black configuration removed - using ruff format instead
 
+[tool.pytest.ini_options]
+# A bare `pytest` must not wander into fuzz/, which is a separate uv project pinned to 3.14
+# and unimportable under this one's interpreter.
+testpaths = ["test"]
+
 [tool.coverage.run]
 # don't attempt code coverage for the CLI entrypoints
 omit = ["fickling/__main__.py", "fickling/cli.py"]
@@ -86,6 +91,7 @@ exclude = [
   "/.github",
   "/test",
   "/example",
+  "/fuzz",
   "/pickle_scanning_benchmark",
   "/.gitignore",
   "/Makefile",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,11 @@ Source = "https://github.com/trailofbits/fickling"
 
 # Black configuration removed - using ruff format instead
 
+[tool.pytest.ini_options]
+# A bare `pytest` must not wander into fuzz/, which is a separate uv project pinned to 3.14
+# and unimportable under this one's interpreter.
+testpaths = ["test"]
+
 [tool.coverage.run]
 # don't attempt code coverage for the CLI entrypoints
 omit = ["fickling/__main__.py", "fickling/cli.py"]
@@ -87,6 +92,7 @@ exclude = [
   "/.github",
   "/test",
   "/example",
+  "/fuzz",
   "/pickle_scanning_benchmark",
   "/.gitignore",
   "/Makefile",


### PR DESCRIPTION
It pairs Atheris' coverage feedback with Cisco's pickle generator. Kept as a separate uv project because atheris needs 3.14 and builds from source; the parent lockfile and `make dev` stay untouched. Excluded from the sdist, and pytest is pinned to test/ so a bare `pytest` doesn't wander into fuzz/. 

Crashes and DoS' are not treated as security issues and will be tracked directly on GitHub.