### PR TITLE
Hook pickle Python fallbacks (GHSA-fphw-536r-4p88) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Fickling can help securing AI/ML codebases by automatically scanning pickle file
 models. Fickling hooks the pickle module and verifies imports made when loading a model. It only
 checks the imports against an allowlist of imports from ML libraries that are considered safe, and blocks files that contain other imports.
 
-To enable Fickling security checks simply run the following lines once in your process, before loading any AI/ML models:
+Add the following lines as early as possible, **before importing `torch`, `numpy`, or any other
+library that uses `pickle`**:
 
 ```python
 import fickling

--- a/fickling/hook.py
+++ b/fickling/hook.py
@@ -10,6 +10,13 @@ _original_pickle_loads = pickle.loads
 _original_pickle_Unpickler = pickle.Unpickler
 _original__pickle_Unpickler = _pickle.Unpickler
 
+# Lib/pickle.py defines the Python implementations unconditionally and only shadows the
+# public names with the _pickle (C) versions on a successful import. The underscore names 
+# stay bound to working unpicklers, so they have to be hooked too.
+_original_pickle__load = pickle._load
+_original_pickle__loads = pickle._loads
+_original_pickle__Unpickler = pickle._Unpickler
+
 
 class FicklingSafetyUnpickler:
     """
@@ -33,12 +40,15 @@ def run_hook():
     """Replace pickle.load() and pickle.Unpickler by fickling's safe versions"""
     # Hook functions
     pickle.load = loader.load
+    pickle._load = loader.load
     _pickle.load = loader.load
     pickle.loads = loader.loads
+    pickle._loads = loader.loads
     _pickle.loads = loader.loads
 
     # Hook the Unpickler class
     pickle.Unpickler = FicklingSafetyUnpickler
+    pickle._Unpickler = FicklingSafetyUnpickler
     _pickle.Unpickler = FicklingSafetyUnpickler
 
 
@@ -60,8 +70,10 @@ def activate_safe_ml_environment(also_allow=None):
 
     # Hook functions
     pickle.load = new_load
+    pickle._load = new_load
     _pickle.load = new_load
     pickle.loads = new_loads
+    pickle._loads = new_loads
     _pickle.loads = new_loads
 
     # Hook Unpickler class - create a subclass that passes also_allow
@@ -72,16 +84,20 @@ def activate_safe_ml_environment(also_allow=None):
             super().__init__(file, *args, also_allow=also_allow, **kwargs)
 
     pickle.Unpickler = SafeMLUnpickler
+    pickle._Unpickler = SafeMLUnpickler
     _pickle.Unpickler = SafeMLUnpickler
 
 
 def remove_hook():
     """Restore original pickle functions and classes"""
     pickle.load = _original_pickle_load
+    pickle._load = _original_pickle__load
     _pickle.load = _original_pickle_load
     pickle.loads = _original_pickle_loads
+    pickle._loads = _original_pickle__loads
     _pickle.loads = _original_pickle_loads
     pickle.Unpickler = _original_pickle_Unpickler
+    pickle._Unpickler = _original_pickle__Unpickler
     _pickle.Unpickler = _original__pickle_Unpickler
 
 

--- a/fickling/hook.py
+++ b/fickling/hook.py
@@ -5,17 +5,28 @@ import pickle
 import fickling.loader as loader
 from fickling.ml import FicklingMLUnpickler
 
-_original_pickle_load = pickle.load
-_original_pickle_loads = pickle.loads
-_original_pickle_Unpickler = pickle.Unpickler
-_original__pickle_Unpickler = _pickle.Unpickler
+# pickle._* are the Python implementations, and are still usable even
+# when the C accelerator is loaded.
+_LOAD_TARGETS = ((pickle, "load"), (pickle, "_load"), (_pickle, "load"))
+_LOADS_TARGETS = ((pickle, "loads"), (pickle, "_loads"), (_pickle, "loads"))
+_UNPICKLER_TARGETS = ((pickle, "Unpickler"), (pickle, "_Unpickler"), (_pickle, "Unpickler"))
 
-# Lib/pickle.py defines the Python implementations unconditionally and only shadows the
-# public names with the _pickle (C) versions on a successful import. The underscore names 
-# stay bound to working unpicklers, so they have to be hooked too.
-_original_pickle__load = pickle._load
-_original_pickle__loads = pickle._loads
-_original_pickle__Unpickler = pickle._Unpickler
+# Captured before patching, for remove_hook().
+_originals = tuple(
+    (module, attr, getattr(module, attr))
+    for module, attr in _LOAD_TARGETS + _LOADS_TARGETS + _UNPICKLER_TARGETS
+)
+
+
+def _patch_entry_points(load, loads, unpickler):
+    """Point every pickle entry point at the given replacements"""
+    for targets, replacement in (
+        (_LOAD_TARGETS, load),
+        (_LOADS_TARGETS, loads),
+        (_UNPICKLER_TARGETS, unpickler),
+    ):
+        for module, attr in targets:
+            setattr(module, attr, replacement)
 
 
 class FicklingSafetyUnpickler:
@@ -37,19 +48,8 @@ class FicklingSafetyUnpickler:
 
 
 def run_hook():
-    """Replace pickle.load() and pickle.Unpickler by fickling's safe versions"""
-    # Hook functions
-    pickle.load = loader.load
-    pickle._load = loader.load
-    _pickle.load = loader.load
-    pickle.loads = loader.loads
-    pickle._loads = loader.loads
-    _pickle.loads = loader.loads
-
-    # Hook the Unpickler class
-    pickle.Unpickler = FicklingSafetyUnpickler
-    pickle._Unpickler = FicklingSafetyUnpickler
-    _pickle.Unpickler = FicklingSafetyUnpickler
+    """Replace pickle's load functions and Unpickler by fickling's safe versions"""
+    _patch_entry_points(loader.load, loader.loads, FicklingSafetyUnpickler)
 
 
 def always_check_safety():
@@ -68,37 +68,19 @@ def activate_safe_ml_environment(also_allow=None):
     def new_loads(data, *args, **kwargs):
         return FicklingMLUnpickler(io.BytesIO(data), also_allow=also_allow, **kwargs).load(*args)
 
-    # Hook functions
-    pickle.load = new_load
-    pickle._load = new_load
-    _pickle.load = new_load
-    pickle.loads = new_loads
-    pickle._loads = new_loads
-    _pickle.loads = new_loads
-
-    # Hook Unpickler class - create a subclass that passes also_allow
     class SafeMLUnpickler(FicklingMLUnpickler):
         """Unpickler with pre-configured also_allow list"""
 
         def __init__(self, file, *args, **kwargs):
             super().__init__(file, *args, also_allow=also_allow, **kwargs)
 
-    pickle.Unpickler = SafeMLUnpickler
-    pickle._Unpickler = SafeMLUnpickler
-    _pickle.Unpickler = SafeMLUnpickler
+    _patch_entry_points(new_load, new_loads, SafeMLUnpickler)
 
 
 def remove_hook():
     """Restore original pickle functions and classes"""
-    pickle.load = _original_pickle_load
-    pickle._load = _original_pickle__load
-    _pickle.load = _original_pickle_load
-    pickle.loads = _original_pickle_loads
-    pickle._loads = _original_pickle__loads
-    _pickle.loads = _original_pickle_loads
-    pickle.Unpickler = _original_pickle_Unpickler
-    pickle._Unpickler = _original_pickle__Unpickler
-    _pickle.Unpickler = _original__pickle_Unpickler
+    for module, attr, original in _originals:
+        setattr(module, attr, original)
 
 
 # Alias

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -50,12 +50,16 @@ class TestHook(unittest.TestCase):
                 self.fail(e)
 
     # https://github.com/trailofbits/fickling/security/advisories/GHSA-wccx-j62j-r448
+    # https://github.com/trailofbits/fickling/security/advisories/GHSA-fphw-536r-4p88
     def test_run_hook_covers_all_entry_points(self):
         data = pickle.dumps(Payload())
         cases = {
             "pickle.load": lambda: pickle.load(io.BytesIO(data)),
             "pickle.loads": lambda: pickle.loads(data),
             "pickle.Unpickler": lambda: pickle.Unpickler(io.BytesIO(data)).load(),
+            "pickle._load": lambda: pickle._load(io.BytesIO(data)),
+            "pickle._loads": lambda: pickle._loads(data),
+            "pickle._Unpickler": lambda: pickle._Unpickler(io.BytesIO(data)).load(),
             "_pickle.load": lambda: _pickle.load(io.BytesIO(data)),
             "_pickle.loads": lambda: _pickle.loads(data),
             "_pickle.Unpickler": lambda: _pickle.Unpickler(io.BytesIO(data)).load(),


### PR DESCRIPTION
`Lib/pickle.py` defines `_load`/`_loads`/`_Unpickler` unconditionally and shadows `load`/`loads`/`Unpickler` with the `_pickle` C implementation on a successful import. The underscore-prefixes ones remain bound to working unpicklers, so calling them could bypass the hook. Patch them too. 

Thanks to @arpitjain099 for the report!