### PR TITLE
Warn hook users of stale pickle references

### DIFF
--- a/fickling/hook.py
+++ b/fickling/hook.py
@@ -1,6 +1,8 @@
 import _pickle
 import io
 import pickle
+import sys
+import warnings
 
 import fickling.loader as loader
 from fickling.ml import FicklingMLUnpickler
@@ -18,6 +20,62 @@ _originals = tuple(
 )
 
 
+class StalePickleReferenceWarning(UserWarning):
+    """A module holds a pre-hook reference to a pickle entry point, so the hook cannot see it"""
+
+
+# These re-read _Unpickler from pickle's globals at call time, so a stale reference to one still
+# reaches the patched unpickler and is not worth reporting.
+_INDIRECT_TARGETS = frozenset({(pickle, "_load"), (pickle, "_loads")})
+
+# id() -> original object, for identity lookups during the sweep.
+_ORIGINALS_BY_ID = {
+    id(original): original
+    for module, attr, original in _originals
+    if (module, attr) not in _INDIRECT_TARGETS
+}
+
+# Distinct from None, which is a legitimate module attribute value.
+_NOT_AN_ORIGINAL = object()
+
+_MAX_REPORTED_REFERENCES = 10
+
+
+def _find_stale_references():
+    """Find `module.attr` bindings still pointing at an unpatched pickle entry point"""
+    stale = []
+    # Snapshot both levels: a concurrent import would resize them mid-iteration.
+    for name, module in list(sys.modules.items()):
+        # fickling keeps its own references to the originals on purpose.
+        if name == "fickling" or name.startswith("fickling."):
+            continue
+        # Read __dict__ directly; getattr()/dir() trigger PEP 562 __getattr__ and lazy loaders.
+        namespace = getattr(module, "__dict__", None)
+        if not isinstance(namespace, dict):
+            continue
+        for attr, value in list(namespace.items()):
+            # Identity, never ==, which would call __eq__ on arbitrary objects.
+            if _ORIGINALS_BY_ID.get(id(value), _NOT_AN_ORIGINAL) is value:
+                stale.append(f"{name}.{attr}")
+    return sorted(stale)
+
+
+def _warn_stale_references():
+    """Warn that some references to pickle escaped the hook, e.g. `from pickle import load`"""
+    stale = _find_stale_references()
+    if not stale:
+        return
+    listed = ", ".join(stale[:_MAX_REPORTED_REFERENCES])
+    if len(stale) > _MAX_REPORTED_REFERENCES:
+        listed += f", and {len(stale) - _MAX_REPORTED_REFERENCES} more"
+    warnings.warn(
+        "fickling's hook cannot intercept these references, which were bound before it was "
+        f"installed: {listed}. Call run_hook() before importing anything that uses pickle.",
+        StalePickleReferenceWarning,
+        stacklevel=4,
+    )
+
+
 def _patch_entry_points(load, loads, unpickler):
     """Point every pickle entry point at the given replacements"""
     for targets, replacement in (
@@ -27,6 +85,7 @@ def _patch_entry_points(load, loads, unpickler):
     ):
         for module, attr in targets:
             setattr(module, attr, replacement)
+    _warn_stale_references()
 
 
 class FicklingSafetyUnpickler:

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -1,7 +1,10 @@
 import _pickle
 import io
 import pickle
+import sys
+import types
 import unittest
+import warnings
 from pickle import UnpicklingError
 
 import numpy
@@ -68,3 +71,88 @@ class TestHook(unittest.TestCase):
             with self.subTest(entry_point=name):
                 with self.assertRaises(UnsafeFileError, msg=f"{name} was not intercepted"):
                     call()
+
+
+_CONSUMER_NAME = "fickling_test_early_importer"
+_INDIRECT_CONSUMER_NAME = "fickling_test_indirect_importer"
+
+
+class EarlyFromImportTestCase(unittest.TestCase):
+    """Base for tests needing a module that from-imported pickle before the hook was installed"""
+
+    def setUp(self):
+        # Order matters: the consumer resolves its names before the hook is installed, and it
+        # lives in sys.modules like any real dependency would.
+        self.consumer = types.ModuleType(_CONSUMER_NAME)
+        exec(
+            "from pickle import Unpickler, load, loads\n"
+            "def read_file(fp): return load(fp)\n"
+            "def read_bytes(data): return loads(data)\n"
+            "def read_unpickler(fp): return Unpickler(fp).load()\n",
+            self.consumer.__dict__,
+        )
+        sys.modules[_CONSUMER_NAME] = self.consumer
+        self.addCleanup(sys.modules.pop, _CONSUMER_NAME, None)
+        self.addCleanup(hook.remove_hook)
+
+
+class TestStaleReferenceWarning(EarlyFromImportTestCase):
+    def test_run_hook_warns_about_stale_references(self):
+        with self.assertWarns(hook.StalePickleReferenceWarning) as caught:
+            hook.run_hook()
+        message = str(caught.warning)
+        for attr in ("load", "loads", "Unpickler"):
+            with self.subTest(attr=attr):
+                self.assertIn(f"{_CONSUMER_NAME}.{attr}", message)
+        self.assertIn("cannot intercept these references", message)
+        self.assertIn("Call run_hook() before importing anything that uses pickle.", message)
+
+    def test_indirect_entry_points_are_not_reported(self):
+        # pickle._load/_loads resolve _Unpickler from pickle's globals when called, so a stale
+        # reference to one still reaches the patched unpickler.
+        indirect = types.ModuleType(_INDIRECT_CONSUMER_NAME)
+        exec("from pickle import _load, _loads", indirect.__dict__)
+        sys.modules[_INDIRECT_CONSUMER_NAME] = indirect
+        self.addCleanup(sys.modules.pop, _INDIRECT_CONSUMER_NAME, None)
+
+        with self.assertWarns(hook.StalePickleReferenceWarning) as caught:
+            hook.run_hook()
+        self.assertNotIn(_INDIRECT_CONSUMER_NAME, str(caught.warning))
+
+        # ...and the reference really is still safe to call.
+        with self.assertRaises(UnsafeFileError):
+            indirect._load(io.BytesIO(pickle.dumps(Payload())))
+
+    def test_activate_safe_ml_environment_warns_too(self):
+        with self.assertWarns(hook.StalePickleReferenceWarning) as caught:
+            hook.activate_safe_ml_environment()
+        self.assertIn(f"{_CONSUMER_NAME}.load", str(caught.warning))
+
+    def test_module_without_stale_reference_is_not_reported(self):
+        # Other test modules legitimately from-import pickle, so only assert on our consumer.
+        sys.modules.pop(_CONSUMER_NAME)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            hook.run_hook()
+        for warning in caught:
+            if warning.category is hook.StalePickleReferenceWarning:
+                self.assertNotIn(_CONSUMER_NAME, str(warning.message))
+
+
+class TestHookWithEarlyFromImport(EarlyFromImportTestCase):
+    """A consumer that from-imported pickle before run_hook() keeps the unpatched functions"""
+
+    # Known gap: the hook rebinds pickle's namespace, which cannot reach references already
+    # copied elsewhere. run_hook() only warns about these; see TestStaleReferenceWarning.
+    @unittest.expectedFailure
+    def test_early_from_import_is_still_hooked(self):
+        hook.run_hook()
+        data = pickle.dumps(Payload())
+        cases = {
+            "from pickle import load": lambda: self.consumer.read_file(io.BytesIO(data)),
+            "from pickle import loads": lambda: self.consumer.read_bytes(data),
+            "from pickle import Unpickler": lambda: self.consumer.read_unpickler(io.BytesIO(data)),
+        }
+        for name, call in cases.items():
+            with self.assertRaises(UnsafeFileError, msg=f"{name} was not intercepted"):
+                call()


### PR DESCRIPTION
The documentation makes it clear that the hook should be installed before any third-party modules get the opportunity to keep references to `pickle` functions (https://github.com/trailofbits/fickling/pull/307/changes/c0fd0b965b256507f110344b752e9df3971dcb04). Since we also keep a reference to them for `remove_hook`, we can recuse into `sys.modules` ("This is a dictionary that maps module names to modules which have already been loaded.") and search for the original ones. 

Still noisy and triggers in regular tests, so this needs more work and a documentation update.