### PR TITLE
FicklingContextManager improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ with fickling.check_safety():
 pickle.load("file.pkl")
 ```
 
+On exit, the context manager restores whatever was installed when it was entered, so a hook
+already in place stays in effect instead of pickle being left unhooked.
+
 #### Option 3: check and load a single file
 
 ```python

--- a/fickling/context.py
+++ b/fickling/context.py
@@ -1,20 +1,13 @@
 import pickle
 
 import fickling.hook as hook
-import fickling.loader as loader
-from fickling.analysis import Severity
 
 
 class FicklingContextManager:
-    def __init__(self, max_acceptable_severity=Severity.LIKELY_SAFE):
+    def __init__(self):
         self.original_pickle_load = pickle.load
-        self.max_acceptable_severity = max_acceptable_severity
 
     def __enter__(self):
-        # Modify the `hook_pickle_load` function to use the imported loader
-        wrapped_load = lambda file, *args, **kwargs: loader.load(  # noqa
-            file, max_acceptable_severity=self.max_acceptable_severity
-        )
         hook.run_hook()
         return self
 

--- a/fickling/context.py
+++ b/fickling/context.py
@@ -1,18 +1,21 @@
-import pickle
-
 import fickling.hook as hook
 
 
 class FicklingContextManager:
     def __init__(self):
-        self.original_pickle_load = pickle.load
+        self.previous_entry_points = None
 
     def __enter__(self):
+        # Snapshot instead of calling remove_hook() on exit, so we restore a
+        # hook that was already installed rather than unhooking pickle.
+        self.previous_entry_points = hook.snapshot_entry_points()
         hook.run_hook()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pickle.load = self.original_pickle_load
+    def __exit__(self, *exc_info):
+        if self.previous_entry_points is not None:
+            hook.restore_entry_points(self.previous_entry_points)
+            self.previous_entry_points = None
 
 
 def check_safety():

--- a/fickling/hook.py
+++ b/fickling/hook.py
@@ -10,12 +10,22 @@ from fickling.ml import FicklingMLUnpickler
 _LOAD_TARGETS = ((pickle, "load"), (pickle, "_load"), (_pickle, "load"))
 _LOADS_TARGETS = ((pickle, "loads"), (pickle, "_loads"), (_pickle, "loads"))
 _UNPICKLER_TARGETS = ((pickle, "Unpickler"), (pickle, "_Unpickler"), (_pickle, "Unpickler"))
+_ALL_TARGETS = _LOAD_TARGETS + _LOADS_TARGETS + _UNPICKLER_TARGETS
+
+
+def snapshot_entry_points():
+    """Capture the current value of every entry point fickling patches"""
+    return tuple((module, attr, getattr(module, attr)) for module, attr in _ALL_TARGETS)
+
+
+def restore_entry_points(snapshot):
+    """Restore the entry points captured by snapshot_entry_points()"""
+    for module, attr, value in snapshot:
+        setattr(module, attr, value)
+
 
 # Captured before patching, for remove_hook().
-_originals = tuple(
-    (module, attr, getattr(module, attr))
-    for module, attr in _LOAD_TARGETS + _LOADS_TARGETS + _UNPICKLER_TARGETS
-)
+_originals = snapshot_entry_points()
 
 
 def _patch_entry_points(load, loads, unpickler):
@@ -79,8 +89,7 @@ def activate_safe_ml_environment(also_allow=None):
 
 def remove_hook():
     """Restore original pickle functions and classes"""
-    for module, attr, original in _originals:
-        setattr(module, attr, original)
+    restore_entry_points(_originals)
 
 
 # Alias

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -1,0 +1,81 @@
+import _pickle
+import io
+import pickle
+import unittest
+
+import fickling
+import fickling.hook as hook
+from fickling.exception import UnsafeFileError
+
+
+class Payload:
+    def __reduce__(self):
+        import os
+
+        return (os.system, ("echo 'I should have been stopped'",))
+
+
+class TestContextManager(unittest.TestCase):
+    def setUp(self):
+        self.entry_points = hook.snapshot_entry_points()
+
+    def tearDown(self):
+        hook.restore_entry_points(self.entry_points)
+
+    def assert_entry_points_restored(self):
+        for module, attr, original in self.entry_points:
+            with self.subTest(entry_point=f"{module.__name__}.{attr}"):
+                self.assertIs(getattr(module, attr), original)
+
+    def test_all_entry_points_hooked(self):
+        data = pickle.dumps(Payload())
+        with fickling.check_safety():
+            cases = {
+                "pickle.load": lambda: pickle.load(io.BytesIO(data)),
+                "pickle.loads": lambda: pickle.loads(data),
+                "pickle.Unpickler": lambda: pickle.Unpickler(io.BytesIO(data)).load(),
+                "pickle._load": lambda: pickle._load(io.BytesIO(data)),
+                "pickle._loads": lambda: pickle._loads(data),
+                "pickle._Unpickler": lambda: pickle._Unpickler(io.BytesIO(data)).load(),
+                "_pickle.load": lambda: _pickle.load(io.BytesIO(data)),
+                "_pickle.loads": lambda: _pickle.loads(data),
+                "_pickle.Unpickler": lambda: _pickle.Unpickler(io.BytesIO(data)).load(),
+            }
+            for name, call in cases.items():
+                with self.subTest(entry_point=name):
+                    with self.assertRaises(UnsafeFileError, msg=f"{name} was not intercepted"):
+                        call()
+
+    def test_all_entry_points_restored(self):
+        with fickling.check_safety():
+            pass
+        self.assert_entry_points_restored()
+
+    def test_entry_points_restored_on_exception(self):
+        with self.assertRaises(UnsafeFileError):
+            with fickling.check_safety():
+                pickle.loads(pickle.dumps(Payload()))
+        self.assert_entry_points_restored()
+
+    def test_preexisting_hook_is_restored(self):
+        hook.activate_safe_ml_environment()
+        ml_entry_points = hook.snapshot_entry_points()
+        with fickling.check_safety():
+            pass
+        for module, attr, ml_value in ml_entry_points:
+            with self.subTest(entry_point=f"{module.__name__}.{attr}"):
+                self.assertIs(getattr(module, attr), ml_value)
+
+    def test_nested(self):
+        with fickling.check_safety():
+            outer = hook.snapshot_entry_points()
+            with fickling.check_safety():
+                pass
+            for module, attr, outer_value in outer:
+                with self.subTest(entry_point=f"{module.__name__}.{attr}"):
+                    self.assertIs(getattr(module, attr), outer_value)
+        self.assert_entry_points_restored()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This fixes #241: `__exit__` would only reset `pickle.load`, leaving the other eight entry points hooked; snapshot on enter so an already-installed hook survives. Also drop `max_acceptable_severity`, which never had any effect.