### PR TITLE
Fix stdlib submodules flagged as non-standard imports

### DIFF
--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -275,7 +275,7 @@ PRIVATE_STDLIB_MODULE_ALLOWLIST: frozenset[str] = frozenset({"__future__"})
 
 
 def is_std_module(module_name: str) -> bool:
-    return module_name in BUILTIN_STDLIB_MODULE_NAMES
+    return module_name.partition(".")[0] in BUILTIN_STDLIB_MODULE_NAMES
 
 
 def is_private_or_dunder_stdlib_module(name: str) -> bool:
@@ -692,7 +692,7 @@ class ASTProperties(ast.NodeVisitor):
             and node.module is not None
             and is_std_module(node.module)
             and (
-                not is_private_or_dunder_stdlib_module(node.module)
+                not any(is_private_or_dunder_stdlib_module(c) for c in node.module.split("."))
                 or _is_allowed_private_import(node)
             )
         ):

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -7,13 +7,15 @@ from fickling.fickle import Pickled
 
 class TestAnalysis(TestCase):
     def test_benign_pickle(self):
-        pickled = Pickled(
-            [
-                op.Proto.create(4),
-                op.ShortBinUnicode("collections"),
-                op.ShortBinUnicode("deque"),
-                op.StackGlobal(),
-                op.Stop(),
-            ]
-        )
-        self.assertEqual(check_safety(pickled).severity, Severity.LIKELY_SAFE)
+        for module, name in (("collections", "deque"), ("collections.abc", "Iterable")):
+            with self.subTest(module=module):
+                pickled = Pickled(
+                    [
+                        op.Proto.create(4),
+                        op.ShortBinUnicode(module),
+                        op.ShortBinUnicode(name),
+                        op.StackGlobal(),
+                        op.Stop(),
+                    ]
+                )
+                self.assertEqual(check_safety(pickled).severity, Severity.LIKELY_SAFE)


### PR DESCRIPTION
`sys.stdlib_module_names` only lists top-level names so submodules like `collections.abc` were marked `LIKELY_UNSAFE`. Match on the first component; `UNSAFE_IMPORTS` still catches dangerous ones like `os.path`, etc.