### PR TITLE
Align FRAME boundaries handling with CPython

### DIFF
--- a/fickling/cli.py
+++ b/fickling/cli.py
@@ -318,11 +318,19 @@ def main(argv: list[str] | None = None) -> int:
                     "Warning: The last opcode of the input file was expected to be STOP, but was "
                     f"in fact {pickled[-1].info.name}"
                 )
-            pickled.insert_python_eval(
-                args.inject,
-                run_first=not args.run_last,
-                use_output_as_unpickle_result=args.replace_result,
-            )
+            try:
+                pickled.insert_python_eval(
+                    args.inject,
+                    run_first=not args.run_last,
+                    use_output_as_unpickle_result=args.replace_result,
+                )
+            except fickle.InterpretationError as e:
+                sys.stderr.write(
+                    f"Error: refusing to inject into this file. {e!s}\n"
+                    "Rewriting it would recompute the FRAME length and produce a well-formed "
+                    "pickle, hiding the inconsistency. Use --check-safety to analyze it.\n"
+                )
+                return EXIT_ERROR
             pickled.dump(buffer)
             for pickled in stacked_pickled[args.inject_target + 1 :]:
                 pickled.dump(buffer)
@@ -363,7 +371,14 @@ def main(argv: list[str] | None = None) -> int:
                         "This pickle file may contain an expansion attack. "
                         "Use --check-safety to analyze it.\n"
                     )
-                    return 1
+                    return EXIT_UNSAFE
+                except fickle.InterpretationError as e:
+                    sys.stderr.write(
+                        f"Error: this pickle file cannot be interpreted. {e!s}\n"
+                        "It may be malformed, or crafted so that what unpickling runs differs "
+                        "from what a linear reader sees. Use --check-safety to analyze it.\n"
+                    )
+                    return EXIT_UNSAFE
                 var_id = interpreter.next_variable_id
     else:
         pickled = fickle.Pickled(

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -752,9 +752,6 @@ class Pickled(OpcodeSequence):
         self._has_cycles: bool = False
         self._has_interpretation_error: bool = False
         self._has_resource_exhaustion: bool = False
-        # Whether the opcode sequence was edited after being parsed. Editing invalidates the
-        # byte lengths declared by any FRAME opcodes, so they have to be recomputed on output.
-        self._was_edited: bool = False
         self._frame_violation: str | None | _Unchecked = _UNCHECKED
 
     def __len__(self) -> int:
@@ -770,7 +767,6 @@ class Pickled(OpcodeSequence):
         self._opcodes.insert(index, opcode)
         self._ast = None
         self._properties = None
-        self._was_edited = True
 
     def _is_constant_type(self, obj: Any) -> bool:
         return isinstance(obj, int | float | str | bytes)
@@ -1040,20 +1036,21 @@ class Pickled(OpcodeSequence):
         self._opcodes[index] = item
         self._ast = None
         self._properties = None
-        self._was_edited = True
 
     def __delitem__(self, index: int):
         del self._opcodes[index]
         self._ast = None
         self._properties = None
-        self._was_edited = True
 
     def _reframed_opcodes(self) -> Iterator[bytes]:
         """Yield the serialization of each opcode, recomputing FRAME lengths as needed.
 
-        FRAME declares how many bytes follow it. Inserting opcodes invalidates that count, and the
-        result no longer loads. CPython 3.14.7 and 3.13.15 enforce this in the C unpickler, and the
-        pure-Python unpickler always has.
+        FRAME declares how many bytes follow it. Editing the opcode sequence invalidates that
+        count, and the result no longer loads. CPython 3.14.7 and 3.13.15 enforce this in the C
+        unpickler, and the pure-Python unpickler always has.
+
+        For an unedited pickle every recomputed length matches the one already there, so this is
+        also the identity transform on anything that came out of `Pickled.load()`.
 
         Frame membership uses each frame's original extent, not everything up to the next FRAME.
         Frames are not necessarily contiguous: CPython writes large objects outside any frame, so a
@@ -1084,19 +1081,28 @@ class Pickled(OpcodeSequence):
             yield from body
             i = j
 
-    def _output_chunks(self) -> Iterator[bytes]:
-        if not self._was_edited:
+    def _output_chunks(self, reframe: bool) -> Iterator[bytes]:
+        if not reframe:
             return (opcode.data for opcode in self)
         return self._reframed_opcodes()
 
-    def dumps(self) -> bytes:
+    def dumps(self, reframe: bool = True) -> bytes:
+        """Serialize the opcode sequence back to bytes.
+
+        :arg reframe: recompute the byte lengths declared by FRAME opcodes. Any edit to the
+            opcode sequence invalidates those lengths, and a pickle carrying a stale one no
+            longer loads. Recomputing is the identity transform on an unedited pickle, so it is
+            on by default. Pass False to emit each opcode's bytes verbatim, which preserves the
+            input exactly even when its frames are inconsistent.
+        """
         b = bytearray()
-        for chunk in self._output_chunks():
+        for chunk in self._output_chunks(reframe):
             b.extend(chunk)
         return bytes(b)
 
-    def dump(self, file: BinaryIO):
-        for chunk in self._output_chunks():
+    def dump(self, file: BinaryIO, reframe: bool = True):
+        """Serialize the opcode sequence to `file`. See `dumps()` for `reframe`."""
+        for chunk in self._output_chunks(reframe):
             file.write(chunk)
 
     def dumps_partial(self, from_idx: int, to_idx: int) -> bytes:

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -733,6 +733,13 @@ class InterpretationError(PickleDecodeError):
     pass
 
 
+class _Unchecked:
+    """Sentinel distinguishing "no frame violation" from "not looked for one yet" """
+
+
+_UNCHECKED = _Unchecked()
+
+
 class Pickled(OpcodeSequence):
     def __init__(self, opcodes: Iterable[Opcode], has_invalid_opcode: bool = False):
         self._opcodes: list[Opcode] = list(opcodes)
@@ -748,6 +755,7 @@ class Pickled(OpcodeSequence):
         # Whether the opcode sequence was edited after being parsed. Editing invalidates the
         # byte lengths declared by any FRAME opcodes, so they have to be recomputed on output.
         self._was_edited: bool = False
+        self._frame_violation: str | None | _Unchecked = _UNCHECKED
 
     def __len__(self) -> int:
         return len(self._opcodes)
@@ -1118,6 +1126,59 @@ class Pickled(OpcodeSequence):
         _ = self.ast  # Ensure interpretation ran
         return self._has_resource_exhaustion
 
+    def _find_frame_violation(self) -> str | None:
+        """Describe the first FRAME boundary violation in the parsed byte stream, if any.
+
+        Two shapes count as violations, the same two CPython 3.14.7 and 3.13.15 now reject:
+        - an opcode whose bytes run past the end of its frame
+        - a FRAME opening before the previous one closed
+
+        Before those versions the C unpickler read straight past a frame end and executed whatever
+        followed. A linear reader such as this parser or `pickletools` instead counts those bytes
+        as part of the oversized argument, so an undersized frame hides the opcodes a pickle really
+        runs. See python/cpython#154848.
+
+        One case here is deliberately stricter than CPython, which checks per read rather than per
+        opcode and so allows a frame to end exactly between an opcode's header and its payload.
+        That case is benign, since the payload read falls through to the file and returns the same
+        bytes a linear reader takes. It is still reported, for two reasons:
+        - matching it means modelling per-opcode read granularity, which differs between CPython's
+          two unpickler implementations
+        - no pickler emits it, because `_Framer.write_large_bytes()` commits the frame before
+          writing an opcode header, so emitted frames always end on an opcode boundary
+
+        Inserted opcodes have no position and are skipped. They are not part of the byte stream
+        under validation, and `_reframed_opcodes()` recomputes their lengths on output.
+        """
+        frame_end: int | None = None
+        for opcode in self._opcodes:
+            if opcode.pos is None:
+                continue
+            start = opcode.pos
+            end = start + (len(opcode.data) if opcode.has_data() else len(opcode.info.code))
+            if frame_end is not None:
+                if start >= frame_end:
+                    frame_end = None  # The frame ended cleanly before this opcode.
+                elif end > frame_end:
+                    return (
+                        f"opcode {opcode.info.name} at offset {start} spans {end - start} bytes "
+                        f"and runs past the end of its frame at offset {frame_end}"
+                    )
+            if isinstance(opcode, Frame) and opcode.arg is not None:
+                if frame_end is not None:
+                    return (
+                        f"a new frame begins at offset {start} before the one ending at {frame_end}"
+                    )
+                frame_end = end + opcode.arg
+        return None
+
+    def validate_frames(self) -> None:
+        """Raise InterpretationError if any opcode crosses a FRAME boundary"""
+        if self._frame_violation is _UNCHECKED:
+            self._frame_violation = self._find_frame_violation()
+        if self._frame_violation is not None:
+            raise InterpretationError(self._frame_violation)
+
     @staticmethod
     def make_stream(data: Buffer | BinaryIO) -> BinaryIO:
         if isinstance(data, bytes | bytearray | Buffer):
@@ -1428,6 +1489,7 @@ class Interpreter:
         self._opcodes = iter(())
 
     def run(self):
+        self.pickled.validate_frames()
         while True:
             try:
                 self.step()

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -733,11 +733,38 @@ class InterpretationError(PickleDecodeError):
     pass
 
 
-class _Unchecked:
-    """Sentinel distinguishing "no frame violation" from "not looked for one yet" """
+@dataclass(frozen=True)
+class OpcodeCrossesFrame:
+    """An opcode whose bytes run past the end of the frame containing it."""
+
+    opcode_name: str
+    offset: int
+    span: int
+    frame_end: int
+
+    def __str__(self) -> str:
+        return (
+            f"opcode {self.opcode_name} at offset {self.offset} spans {self.span} bytes "
+            f"and runs past the end of its frame at offset {self.frame_end}"
+        )
 
 
-_UNCHECKED = _Unchecked()
+@dataclass(frozen=True)
+class FrameReopened:
+    """A FRAME opcode that begins before the preceding frame ended."""
+
+    offset: int
+    frame_end: int
+
+    def __str__(self) -> str:
+        return (
+            f"a new frame begins at offset {self.offset} before the one ending at {self.frame_end}"
+        )
+
+
+# The two shapes CPython 3.14.7 and 3.13.15 reject. They carry the offsets rather than a
+# rendered sentence so callers can report them however they like; `str()` gives the sentence.
+FrameViolation = OpcodeCrossesFrame | FrameReopened
 
 
 class Pickled(OpcodeSequence):
@@ -752,7 +779,6 @@ class Pickled(OpcodeSequence):
         self._has_cycles: bool = False
         self._has_interpretation_error: bool = False
         self._has_resource_exhaustion: bool = False
-        self._frame_violation: str | None | _Unchecked = _UNCHECKED
 
     def __len__(self) -> int:
         return len(self._opcodes)
@@ -1137,12 +1163,12 @@ class Pickled(OpcodeSequence):
         _ = self.ast  # Ensure interpretation ran
         return self._has_resource_exhaustion
 
-    def _find_frame_violation(self) -> str | None:
-        """Describe the first FRAME boundary violation in the parsed byte stream, if any.
+    def _find_frame_violation(self) -> FrameViolation | None:
+        """Return the first FRAME boundary violation in the parsed byte stream, or None.
 
         Two shapes count as violations, the same two CPython 3.14.7 and 3.13.15 now reject:
-        - an opcode whose bytes run past the end of its frame
-        - a FRAME opening before the previous one closed
+        - an opcode whose bytes run past the end of its frame (`OpcodeCrossesFrame`)
+        - a FRAME opening before the previous one closed (`FrameReopened`)
 
         Before those versions the C unpickler read straight past a frame end and executed whatever
         followed. A linear reader such as this parser or `pickletools` instead counts those bytes
@@ -1171,15 +1197,15 @@ class Pickled(OpcodeSequence):
                 if start >= frame_end:
                     frame_end = None  # The frame ended cleanly before this opcode.
                 elif end > frame_end:
-                    return (
-                        f"opcode {opcode.info.name} at offset {start} spans {end - start} bytes "
-                        f"and runs past the end of its frame at offset {frame_end}"
+                    return OpcodeCrossesFrame(
+                        opcode_name=opcode.info.name,
+                        offset=start,
+                        span=end - start,
+                        frame_end=frame_end,
                     )
             if isinstance(opcode, Frame) and opcode.arg is not None:
                 if frame_end is not None:
-                    return (
-                        f"a new frame begins at offset {start} before the one ending at {frame_end}"
-                    )
+                    return FrameReopened(offset=start, frame_end=frame_end)
                 frame_end = end + opcode.arg
         return None
 
@@ -1190,10 +1216,9 @@ class Pickled(OpcodeSequence):
         inconsistent would recompute the offending FRAME length and hand back a well-formed file,
         laundering away the very divergence that makes it worth flagging.
         """
-        if self._frame_violation is _UNCHECKED:
-            self._frame_violation = self._find_frame_violation()
-        if self._frame_violation is not None:
-            raise InterpretationError(self._frame_violation)
+        violation = self._find_frame_violation()
+        if violation is not None:
+            raise InterpretationError(str(violation))
 
     @staticmethod
     def make_stream(data: Buffer | BinaryIO) -> BinaryIO:

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -745,6 +745,9 @@ class Pickled(OpcodeSequence):
         self._has_cycles: bool = False
         self._has_interpretation_error: bool = False
         self._has_resource_exhaustion: bool = False
+        # Whether the opcode sequence was edited after being parsed. Editing invalidates the
+        # byte lengths declared by any FRAME opcodes, so they have to be recomputed on output.
+        self._was_edited: bool = False
 
     def __len__(self) -> int:
         return len(self._opcodes)
@@ -759,6 +762,7 @@ class Pickled(OpcodeSequence):
         self._opcodes.insert(index, opcode)
         self._ast = None
         self._properties = None
+        self._was_edited = True
 
     def _is_constant_type(self, obj: Any) -> bool:
         return isinstance(obj, int | float | str | bytes)
@@ -1023,21 +1027,64 @@ class Pickled(OpcodeSequence):
         self._opcodes[index] = item
         self._ast = None
         self._properties = None
+        self._was_edited = True
 
     def __delitem__(self, index: int):
         del self._opcodes[index]
         self._ast = None
         self._properties = None
+        self._was_edited = True
+
+    def _reframed_opcodes(self) -> Iterator[bytes]:
+        """Yield the serialization of each opcode, recomputing FRAME lengths as needed.
+
+        FRAME declares how many bytes follow it. Inserting opcodes invalidates that count, and the
+        result no longer loads. CPython 3.14.7 and 3.13.15 enforce this in the C unpickler, and the
+        pure-Python unpickler always has.
+
+        Frame membership uses each frame's original extent, not everything up to the next FRAME.
+        Frames are not necessarily contiguous: CPython writes large objects outside any frame, so a
+        pickle can be framed, then unframed, then framed again.
+
+        Two kinds of opcode land in a frame:
+        - a parsed opcode, if its position precedes the frame's original end
+        - an inserted opcode, which has no position, if the frame encloses it
+        """
+        opcodes = self._opcodes
+        i = 0
+        while i < len(opcodes):
+            opcode = opcodes[i]
+            if not isinstance(opcode, Frame) or opcode.pos is None or opcode.arg is None:
+                yield opcode.data
+                i += 1
+                continue
+            frame_end = opcode.pos + len(opcode.data) + opcode.arg
+            body: list[bytes] = []
+            j = i + 1
+            while j < len(opcodes):
+                member = opcodes[j]
+                if member.pos is not None and member.pos >= frame_end:
+                    break
+                body.append(member.data)
+                j += 1
+            yield Frame.create(sum(len(b) for b in body)).data
+            yield from body
+            i = j
+
+    def _output_chunks(self) -> Iterator[bytes]:
+        if not self._was_edited:
+            return (opcode.data for opcode in self)
+        return self._reframed_opcodes()
 
     def dumps(self) -> bytes:
         b = bytearray()
-        for opcode in self:
-            b.extend(opcode.data)
+        for chunk in self._output_chunks():
+            b.extend(chunk)
         return bytes(b)
 
     def dump(self, file: BinaryIO):
-        for opcode in self:
-            file.write(opcode.data)
+        for chunk in self._output_chunks():
+            file.write(chunk)
 
     def dumps_partial(self, from_idx: int, to_idx: int) -> bytes:
         """Dump bytecode only between two opcodes
@@ -2082,6 +2129,15 @@ class Stop(Opcode):
 
 class Frame(NoOp):
     name = "FRAME"
+
+    @staticmethod
+    def create(length: int) -> Frame:
+        return Frame(length)
+
+    def encode_body(self) -> bytes:
+        if self.arg is None:
+            raise ValueError("Cannot encode a FRAME opcode without a length")
+        return int(self.arg).to_bytes(8, "little", signed=False)
 
 
 class BinInt1(ConstantInt):

--- a/fickling/fickle.py
+++ b/fickling/fickle.py
@@ -807,6 +807,7 @@ class Pickled(OpcodeSequence):
     def insert_python_obj(self, index: int, obj: Any) -> int:
         """Insert an opcode sequence that constructs a python object on the stack.
         Returns the number of opcodes inserted"""
+        self.validate_frames()
         opcodes = self._encode_python_obj(obj)
         for i, opcode in enumerate(opcodes):
             self.insert(index + i, opcode)
@@ -822,6 +823,7 @@ class Pickled(OpcodeSequence):
     ) -> int:
         if not isinstance(self[-1], Stop):
             raise ValueError("Expected the last opcode to be STOP")
+        self.validate_frames()
         # we need to add the call to GLOBAL before the preexisting code, because the following code
         # can sometimes mess up module lookup (somehow? I, Evan, don't fully understand why yet).
         # So we set up the "import" of `__builtin__.eval` first, then set up the stack for a call
@@ -895,6 +897,7 @@ class Pickled(OpcodeSequence):
         a POP instruction if True"""
         if not isinstance(self[-1], Stop):
             raise ValueError("Expected the last opcode to be STOP")
+        self.validate_frames()
         # NOTE(boyan): this seems to work even without insert GLOBAL at the beginning
         # of the pickle, but see comment in 'insert_python'
         self.insert(-1, Global.create(module, attr))
@@ -914,6 +917,7 @@ class Pickled(OpcodeSequence):
 
         :param magic: magic integer value to add
         :param index: index in opcodes list where to insert the magic"""
+        self.validate_frames()
         self.insert(index, Int(magic))
         self.insert(-1 if index == -1 else index + 1, Pop())
 
@@ -938,6 +942,7 @@ class Pickled(OpcodeSequence):
 
         if not isinstance(self[-1], Stop):
             raise ValueError("Expected the last opcode to be STOP")
+        self.validate_frames()
 
         # Get function name
         fn_match = list(re.match(r"def\s+(.*?)\s*\(", function_definition).groups())
@@ -1173,7 +1178,12 @@ class Pickled(OpcodeSequence):
         return None
 
     def validate_frames(self) -> None:
-        """Raise InterpretationError if any opcode crosses a FRAME boundary"""
+        """Raise InterpretationError if any opcode crosses a FRAME boundary.
+
+        Interpretation and the injection APIs both call this. Rewriting a pickle whose frames are
+        inconsistent would recompute the offending FRAME length and hand back a well-formed file,
+        laundering away the very divergence that makes it worth flagging.
+        """
         if self._frame_violation is _UNCHECKED:
             self._frame_violation = self._find_frame_violation()
         if self._frame_violation is not None:

--- a/fickling/tracing.py
+++ b/fickling/tracing.py
@@ -38,6 +38,9 @@ class Trace:
         print(opcode.name)
 
     def run(self) -> ast.AST:
+        # `Interpreter.run()` validates before stepping, but this drives `step()` itself, so it
+        # has to do the same or a frame-straddling pickle would trace as though it were benign.
+        self.interpreter.pickled.validate_frames()
         while True:
             memory_before = dict(self.interpreter.memory)
             stack_before = Stack(self.interpreter.stack)

--- a/test/test_bypasses.py
+++ b/test/test_bypasses.py
@@ -1,4 +1,6 @@
 import marshal
+import pickle
+import struct
 from unittest import TestCase
 
 import fickling.fickle as op
@@ -784,6 +786,86 @@ class TestBypasses(TestCase):
             "from __future__ import _ssl.RAND_bytes",
         )
         self.assertGreaterEqual(res.severity, Severity.LIKELY_UNSAFE)
+
+    # https://github.com/python/cpython/issues/154848
+    def test_frame_boundary_divergence(self):
+        # BINBYTES declares 0x107 bytes inside a frame holding 2, so `pickle.load(file)` reads
+        # past the frame and runs the buried GLOBAL/REDUCE while fickling sees only a long
+        # bytestring. Hand-assembled because the opcode API cannot express a mismatched FRAME.
+        hidden = (
+            pickle.GLOBAL
+            + b"os\nsystem\n"
+            + pickle.UNICODE
+            + b"echo pwned\n"
+            + pickle.TUPLE1
+            + pickle.REDUCE
+        )
+        payload = (
+            pickle.PROTO
+            + b"\x05"
+            + pickle.NONE
+            + pickle.UNICODE
+            + b"a" * (8192 * 16 - 17)
+            + b"\n"  # push the frame past the read buffer
+            + pickle.POP
+            + pickle.MARK
+            + pickle.FRAME
+            + struct.pack("<Q", 2)  # frame claims 2 bytes...
+            + pickle.BINBYTES
+            + b"\x07\x01\x00\x00"  # ...but BINBYTES reads 0x107 of them
+            + b"\x00\x00"
+            + (hidden + pickle.MARK).ljust(256 + 5, pickle.NONE)
+            + pickle.POP_MARK
+            + pickle.STOP
+        )
+        parsed = Pickled.load(payload)
+        self.assertEqual([], [o for o in parsed if isinstance(o, op.Global)])
+        self.assertGreater(check_safety(parsed).severity, Severity.LIKELY_SAFE)
+
+    # https://github.com/python/cpython/issues/154848
+    def test_frame_boundary_straddle_variants(self):
+        def framed(body, declared_length):
+            return pickle.PROTO + b"\x05" + pickle.FRAME + struct.pack("<Q", declared_length) + body
+
+        for description, payload in (
+            ("BINBYTES", framed(pickle.BINBYTES + struct.pack("<I", 20) + b"A" * 20, 5)),
+            ("SHORT_BINUNICODE", framed(b"\x8c\x14" + b"A" * 20, 3)),
+            ("GLOBAL module", framed(pickle.GLOBAL + b"macos\nsystem\n", 4)),
+            ("GLOBAL attr", framed(pickle.GLOBAL + b"os\nsystem\n", 7)),
+            ("UNICODE", framed(pickle.UNICODE + b"hello world\n", 5)),
+            ("BININT", framed(pickle.BININT + struct.pack("<i", 7), 2)),
+            (
+                "frame opening inside another frame",
+                pickle.PROTO
+                + b"\x05"
+                + pickle.FRAME
+                + struct.pack("<Q", 30)
+                + pickle.NONE
+                + pickle.FRAME
+                + struct.pack("<Q", 2)
+                + pickle.NONE,
+            ),
+        ):
+            with self.subTest(description):
+                parsed = Pickled.load(payload + pickle.STOP)
+                self.assertGreater(check_safety(parsed).severity, Severity.LIKELY_SAFE)
+
+    def test_well_formed_frames_are_not_flagged(self):
+        # Guards the frame check against false positives. The interleaved case matters most, since
+        # CPython writes large objects outside any frame: those bytes legitimately sit between two
+        # frames rather than inside one.
+        for description, obj in (
+            ("small list", [1, 2, 3, 4]),
+            ("large unframed bytes", b"x" * 100000),
+            ("interleaved framed and unframed", [1, b"y" * 100000, 2]),
+            ("several full frames", list(range(200000))),
+            ("nested containers", {"a": [1, 2, {"b": (3, 4)}], "c": [5, 6]}),
+        ):
+            for protocol in (2, 4, 5):
+                with self.subTest(f"{description}, protocol {protocol}"):
+                    parsed = Pickled.load(pickle.dumps(obj, protocol=protocol))
+                    self.assertIsNone(parsed._find_frame_violation())
+                    self.assertEqual(Severity.LIKELY_SAFE, check_safety(parsed).severity)
 
 
 class TestUnsafeModuleCoverage(TestCase):

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -1,3 +1,4 @@
+import pickle
 from ast import unparse
 from contextlib import redirect_stdout
 from functools import wraps
@@ -249,6 +250,58 @@ class TestInterpreter(TestCase):
         )
         self.assertEqual(len(Interpreter(pickled).unused_variables()), 0)
         self.assertEqual(check_safety(pickled).to_dict()["severity"], "LIKELY_SAFE")
+
+    def test_injection_recomputes_frame_lengths(self):
+        # `pickle._loads` is the pure-Python unpickler, which enforces frames on every version;
+        # the C one only started doing so in CPython 3.14.7 / 3.13.15.
+        for description, inject, expected in (
+            (
+                "insert_python_eval",
+                lambda p: p.insert_python_eval("[5, 6, 7, 8]", use_output_as_unpickle_result=True),
+                [5, 6, 7, 8],
+            ),
+            (
+                "insert_python run last",
+                lambda p: p.insert_python_eval(
+                    "[5, 6, 7, 8]", run_first=False, use_output_as_unpickle_result=False
+                ),
+                [1, 2, 3, 4],
+            ),
+            (
+                "append_python",
+                lambda p: p.append_python("[9]", pop_result=True),
+                [1, 2, 3, 4],
+            ),
+            (
+                "insert_magic_int",
+                lambda p: p.insert_magic_int(0xDEADBEEF),
+                [1, 2, 3, 4],
+            ),
+        ):
+            with self.subTest(description):
+                loaded = Pickled.load(dumps([1, 2, 3, 4], protocol=5))
+                inject(loaded)
+                self.assertEqual(expected, pickle._loads(loaded.dumps()))
+
+    def test_dumps_is_byte_identical_without_edits(self):
+        for description, obj in (
+            ("small list", [1, 2, 3, 4]),
+            ("large unframed bytes", b"x" * 100000),
+            # Framed, then unframed, then framed again: CPython puts large objects outside frames.
+            ("interleaved framed and unframed", [1, b"y" * 100000, 2]),
+            ("several full frames", list(range(200000))),
+        ):
+            for protocol in (2, 4, 5):
+                with self.subTest(f"{description}, protocol {protocol}"):
+                    original = dumps(obj, protocol=protocol)
+                    self.assertEqual(original, Pickled.load(original).dumps())
+
+    def test_injection_preserves_unframed_regions(self):
+        # Same interleaved shape as above, but edited, so the frames get recomputed.
+        obj = [1, b"y" * 100000, 2]
+        loaded = Pickled.load(dumps(obj, protocol=5))
+        loaded.insert_python_eval("None", run_first=False, use_output_as_unpickle_result=False)
+        self.assertEqual(obj, pickle._loads(loaded.dumps()))
 
     @stacked_correctness_test([1, 2, 3, 4], [5, 6, 7, 8])
     def test_stacked_pickles(self):


### PR DESCRIPTION
CPython 3.14.7 / 3.13.15 now enforces frame boundaries in the C unpickler (the pure-Python one always has).

Injecting opcodes into a parsed pickle left the enclosing `FRAME` declaring its original byte count, so the output no longer loaded. `dumps()` now recomputes `FRAME` lengths on every dump; pass `reframe=False` to preserve the input byte for byte. Rewriting would then hide a malformed frame, so the injection APIs refuse a pickle whose frames are already inconsistent.

During evaluation, an opcode argument could be declared longer than the frame containing it. Older CPython read past the frame end and executed what followed, while fickling reads linearly and counts those bytes as part of the oversized argument, so the analyzer never saw the opcodes the pickle actually ran (see python/cpython#154848). `Pickled.validate_frames()` now raises `InterpretationError` for an opcode running past its frame end, or a `FRAME` opening before the previous one closed. It also runs under `fickling --trace` (which previously skipped it and exited 0), and the CLI reports it as `EXIT_UNSAFE` instead of an uncaught traceback.