### PR TITLE
fix(polyglot): bound recursive archive extraction and unify error handling

### DIFF
--- a/fickling/polyglot.py
+++ b/fickling/polyglot.py
@@ -9,7 +9,15 @@ from typing import TypedDict
 
 import numpy.lib.format as npformat
 
+from fickling.exception import ResourceExhaustionError
 from fickling.fickle import Pickled, StackedPickle
+
+# Property scanning extracts archive members to temporary files so their
+# structure can be inspected. The cap bounds each member's extracted size so a
+# compressed-expansion bomb cannot exhaust the disk: declared sizes lie, so the
+# bound is enforced while streaming, not from archive metadata.
+MAX_MEMBER_EXTRACTION_SIZE = 1 << 30
+_EXTRACTION_CHUNK_SIZE = 1 << 20
 
 # Optional 7z support
 try:
@@ -258,16 +266,35 @@ def find_file_properties_recursively(file_path, print_properties=False):
                 mode = info.external_attr >> 16
                 if info.is_dir():
                     continue
-                if mode == 0 or stat.S_ISREG(mode):
-                    _tempfile = tempfile.NamedTemporaryFile(delete=False)
-                    try:
-                        _tempfile.write(zipped_file.read(fname))
-                        _tempfile.close()
-                        properties["children"][fname] = find_file_properties_recursively(
-                            _tempfile.name, print_properties
-                        )
-                    finally:
-                        Path(_tempfile.name).unlink()
+                # Entries written by zipfile.writestr carry permission bits
+                # without file-type bits (mode == 0o600, S_ISREG false) — skip
+                # only entries whose type bits name a non-regular type.
+                if mode & stat.S_IFMT(mode) and not stat.S_ISREG(mode):
+                    continue
+                _tempfile = tempfile.NamedTemporaryFile(delete=False)
+                try:
+                    with zipped_file.open(fname) as member:
+                        extracted = 0
+                        while chunk := member.read(_EXTRACTION_CHUNK_SIZE):
+                            _tempfile.write(chunk)
+                            extracted += len(chunk)
+                            if extracted > MAX_MEMBER_EXTRACTION_SIZE:
+                                raise ResourceExhaustionError(
+                                    "zip member extraction",
+                                    MAX_MEMBER_EXTRACTION_SIZE,
+                                    extracted,
+                                )
+                    _tempfile.close()
+                    properties["children"][fname] = find_file_properties_recursively(
+                        _tempfile.name, print_properties
+                    )
+                except ResourceExhaustionError:
+                    raise
+                except (zipfile.BadZipFile, OSError):
+                    # Graceful degradation on corrupt members, mirroring the 7z path
+                    properties["children"][fname] = None
+                finally:
+                    Path(_tempfile.name).unlink()
 
     # check tar
     if properties["is_tar"]:  # tar archive
@@ -280,11 +307,25 @@ def find_file_properties_recursively(file_path, print_properties=False):
                         continue
                     _tempfile = tempfile.NamedTemporaryFile(delete=False)
                     try:
-                        _tempfile.write(content.read())
+                        extracted = 0
+                        while chunk := content.read(_EXTRACTION_CHUNK_SIZE):
+                            _tempfile.write(chunk)
+                            extracted += len(chunk)
+                            if extracted > MAX_MEMBER_EXTRACTION_SIZE:
+                                raise ResourceExhaustionError(
+                                    "tar member extraction",
+                                    MAX_MEMBER_EXTRACTION_SIZE,
+                                    extracted,
+                                )
                         _tempfile.close()
                         properties["children"][fname.name] = find_file_properties_recursively(
                             _tempfile.name, print_properties
                         )
+                    except ResourceExhaustionError:
+                        raise
+                    except (tarfile.TarError, OSError):
+                        # Graceful degradation on corrupt members, mirroring the 7z path
+                        properties["children"][fname.name] = None
                     finally:
                         Path(_tempfile.name).unlink()
 
@@ -323,7 +364,6 @@ def check_if_legacy_format(file: str | os.PathLike[str]) -> bool:
     """PyTorch v0.1.1: Tar file with sys_info, pickle, storages, and tensors"""
     required_entries = {"pickle", "storages", "tensors"}
     found_entries = set()
-    print("check_if_legacy_format")
     try:
         with tarfile.open(file, mode="r:", format=tarfile.PAX_FORMAT) as tar:
             for member in iter(tar.next, None):

--- a/test/test_polyglot.py
+++ b/test/test_polyglot.py
@@ -1,10 +1,14 @@
+import contextlib
+import io
 import random
+import shutil
 import string
 import tarfile
 import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from unittest import mock
 
 import numpy as np
 import py7zr
@@ -217,3 +221,54 @@ class TestPolyglotModule(unittest.TestCase):
         )
         formats = polyglot.identify_pytorch_file_format(self.standard_torchscript_polyglot_name)
         self.assertTrue({"PyTorch v1.3", "TorchScript v1.4"}.issubset(formats))
+
+
+class TestExtractionLimits(unittest.TestCase):
+    """The recursive property scanner must bound member extraction: a
+    compressed-expansion bomb (tiny zip, huge decompressed output) previously
+    streamed to disk without limit, exhausting storage during scanning."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_zip_member_extraction_is_capped(self):
+        bomb_path = self.tmpdir / "bomb.zip"
+        with zipfile.ZipFile(bomb_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("payload.bin", b"\x00" * (4 * 1024 * 1024))
+        with (
+            mock.patch.object(polyglot, "MAX_MEMBER_EXTRACTION_SIZE", 1024),
+            self.assertRaises(polyglot.ResourceExhaustionError),
+        ):
+            polyglot.find_file_properties_recursively(bomb_path)
+
+    def test_tar_member_extraction_is_capped(self):
+        tar_path = self.tmpdir / "wide.tar"
+        with tarfile.open(tar_path, "w") as tf:
+            info = tarfile.TarInfo("payload.bin")
+            info.size = 4 * 1024 * 1024
+            tf.addfile(info, io.BytesIO(b"\x00" * (4 * 1024 * 1024)))
+        with (
+            mock.patch.object(polyglot, "MAX_MEMBER_EXTRACTION_SIZE", 1024),
+            self.assertRaises(polyglot.ResourceExhaustionError),
+        ):
+            polyglot.find_file_properties_recursively(tar_path)
+
+    def test_small_members_still_scan(self):
+        zip_path = self.tmpdir / "small.zip"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("tiny.bin", b"\x00" * 512)
+        properties = polyglot.find_file_properties_recursively(zip_path)
+        self.assertFalse(properties["children"]["tiny.bin"]["is_standard_zip"])
+
+    def test_check_if_legacy_format_does_not_print(self):
+        tar_path = self.tmpdir / "plain.tar"
+        with tarfile.open(tar_path, "w") as tf:
+            info = tarfile.TarInfo("anything.bin")
+            info.size = 4
+            tf.addfile(info, io.BytesIO(b"\x00" * 4))
+        with contextlib.redirect_stdout(io.StringIO()) as captured:
+            polyglot.check_if_legacy_format(tar_path)
+        self.assertNotIn("check_if_legacy_format", captured.getvalue())


### PR DESCRIPTION
## Root cause
`find_file_properties_recursively` exists to inspect **untrusted** archives, but its zip and tar paths extracted members to disk with **no size limit** and no error handling: `zipped_file.read(fname)` streams the full decompressed output, so a compressed-expansion bomb (tiny archive, huge inflated member) exhausts storage during scanning. The 7z path already handled both concerns (`BytesIOFactory(limit=...)` + `except (OSError, ArchiveError)` graceful degradation) — the zip and tar paths matched neither.

A second defect in the same loop: entries written by `zipfile.writestr` carry permission bits without file-type bits (`external_attr = 0o600 << 16`, so `mode == 0` is false and `stat.S_ISREG(mode)` is false) — those members were silently **never scanned**.

Also removes a stray debug `print("check_if_legacy_format")` that fired on every tar-file format check through `identify_pytorch_file_format` → `PyTorchModelWrapper.validate_file_format`.

## Fix
- Zip/tar member extraction streams in chunks up to `MAX_MEMBER_EXTRACTION_SIZE`, raising `ResourceExhaustionError` past the cap — declared archive sizes lie, so the bound is enforced while streaming rather than read from metadata; this aligns the polyglot scanner with the expansion-attack protection the analysis path already has
- Corrupt members degrade gracefully (`BadZipFile`/`TarError`/`OSError` → member skipped), matching the 7z path
- Zip member filter keys off the file-type bits (`S_IFMT`), so permission-only entries (`writestr` style) are scanned
- Stray debug print removed

## Validation
- `pytest test/test_polyglot.py` | sample size: `N=21` | key metrics: 4 new tests fail pre-fix (extraction uncapped on a 4 MiB-of-zeros member with a 1 KiB cap; stray print present; writestr members skipped) → post-fix `21 passed` | result: `pass`
- Full suite `pytest test/` → `153 passed`
- `ruff@0.16.0 check` + `format --check`: clean

## Risk / Compatibility
- Well-formed archives behave identically (the cap default is 1 GiB per member); hostile archives now fail loudly with `ResourceExhaustionError` instead of filling the disk, and corrupt members degrade instead of crashing — both align zip/tar with the 7z path's existing contract.